### PR TITLE
Gradle itests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,7 @@ pipeline {
             steps {
                 timeout(time: 10, unit: 'MINUTES') {
                     dockerd {}
-                    sh './gradlew build'
+                    sh './gradlew build -PskipITests'
                 }
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,10 @@ ext.quietTest = {
 	project.hasProperty("quiet")
 }
 
+ext.skipITest = {
+	project.hasProperty("skipITest")
+}
+
 repositories {
 	mavenCentral()
 	mavenLocal()
@@ -65,6 +69,11 @@ subprojects {
 		def styler = [(TestResult.ResultType.FAILURE): { msg -> "\033[31m${msg}\033[0m" },
 					(TestResult.ResultType.SKIPPED): { msg -> "\033[33m${msg}\033[0m" },
 					(TestResult.ResultType.SUCCESS): { msg -> "\033[32m${msg}\033[0m" }]
+
+
+		if(project.skipITest()) {
+			exclude "**/*IntegrationTest*"
+		}
 
 		def parallel = { desc ->
 			if (project.quietTest()) {


### PR DESCRIPTION
Adds an option to skip all tests with `IntegrationTest` in the name