### PR TITLE
Docker Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,31 @@
 ```
 Because the Docker images are built automatically, a docker daemon must be available.
 
-## Running via docker-compose
+
+### Tests
+Tests are run automatically with `./gradlew build`. Even if the tests fail, the artifacts are built and can be run.
+
+To run tests with quiet logs, add `-Pquiet`. This should not be used with parallel builds.
+
+To run a single test suite, execute:
+```
+./gradlew module:test --test fullClassName
+```
+
+#### Integration Tests
+The integration tests require that Docker is running.
+
+To skip integration tests, add `-PskipITests`.
+
+## Running
+1. Boot up an [Apache Cassandra](https://cassandra.apache.org/) instance using the default hostname and ports: `localhost:9042`.
+
+2. To start the services, execute:
+	```
+	./gradlew run
+	```
+	
+### Running via docker-compose
 There is a docker-compose environment included in this repository.
 This will spin up each of the services that make up the multi-int-store as well as any 3rd party services needed by the multi-int-store.
 
@@ -49,33 +73,37 @@ To bring down the services and clean up, execute:
 docker-compose down
 ```
 
-### Accessing
+#### Accessing
 
 The compose environment is configured to expose each of the services to the host OS on a different port. To check the ports examine the output of `docker-compose ps`.
 
-### Tests
-Tests are run automatically with `./gradlew build`. Even if the tests fail, the artifacts are built and can be run.
-
-To run tests with quiet logs, add `-Pquiet`. This should not be used with parallel builds.
-
-To run a single test suite, execute:
-```
-./gradlew module:test --test fullClassName
+### Running via docker stack
+To deploy the full environment onto a swarm, execute:
+```bash
+docker stack deploy -c docker-compose.yml cdr
 ```
 
-#### Integration Tests
-The integration tests require that Docker is running.
+To check the status of all services in the stack, execute:
+```bash
+docker stack services cdr
+```
 
-To skip integration tests, add `-PskipITests`.
+To stream the logs for a specific service, execute:
+```bash
+docker service logs -f <service_name>
+```
 
-## Running
-1. Boot up an [Apache Cassandra](https://cassandra.apache.org/) instance using the default hostname and ports: `localhost:9042`.
+#### Custom Registries
+The compose file in this repo uses variable interpolation to allow for overriding the registry url for the images produced during the build.
 
-2. To start the services, execute:
-	```
-	./gradlew run
-	```
+For example, the build produces an image name that looks like `cnxta/cdr-ingest:<version>` which _implies_ a registry of `docker.io`. This means the full name of the repository is `docker.io/cnxta/cdr-ingest:<version>`.
+In order to make this flexible a variable has been added in the compose file that defaults to this value but can be overridden at deploy time.
 
+*Note:* Docker stack does not actually allow variable interpolation, we will need to run a more complex command to deal with this scenario.
+
+To deploy to a swarm using a custom registry:
+1. re-tag and push images to custom registry
+2. Run 
 ## Build Checks
 ### OWASP
 ```

--- a/README.md
+++ b/README.md
@@ -8,6 +8,22 @@
 ./gradlew build
 ```
 
+## Running via docker-compose
+There is a docker-compose environment included in this repository. 
+This will spin up each of the services that make up the multi-int-store as well as any 3rd party services needed by the multi-int-store.
+
+To start the full environment run `docker-compose up -d`
+
+To check the status of the environment run `docker-compose ps`
+
+To stream the logs to the console run `docker-compose logs -f`
+
+To bring down the services and clean up run `docker-compose down`
+
+### Accessing
+
+The compose environment is configured to expose each of the services to the host OS on a different port. To check the ports examine the output of `docker-compose ps`
+
 ### Tests
 Tests are run automatically with `./gradlew build`. Even if the tests fail, the artifacts are built and can be run.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ```
 
 ## Running via docker-compose
-There is a docker-compose environment included in this repository. 
+There is a docker-compose environment included in this repository.
 This will spin up each of the services that make up the multi-int-store as well as any 3rd party services needed by the multi-int-store.
 
 To start the full environment run `docker-compose up -d`

--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 
 ## Prerequisites
 * Java 11
+* Docker
 
 ## Building
 ```
 ./gradlew build
 ```
+Because the Docker images are built automatically, a docker daemon must be available.
 
 ## Running via docker-compose
 There is a docker-compose environment included in this repository.

--- a/README.md
+++ b/README.md
@@ -12,17 +12,29 @@
 There is a docker-compose environment included in this repository.
 This will spin up each of the services that make up the multi-int-store as well as any 3rd party services needed by the multi-int-store.
 
-To start the full environment run `docker-compose up -d`
+To start the full environment, execute:
+```
+docker-compose up -d
+```
 
-To check the status of the environment run `docker-compose ps`
+To check the status of the environment, execute:
+```
+docker-compose ps
+```
 
-To stream the logs to the console run `docker-compose logs -f`
+To stream the logs to the console, execute:
+```
+docker-compose logs -f
+```
 
-To bring down the services and clean up run `docker-compose down`
+To bring down the services and clean up, execute:
+```
+docker-compose down
+```
 
 ### Accessing
 
-The compose environment is configured to expose each of the services to the host OS on a different port. To check the ports examine the output of `docker-compose ps`
+The compose environment is configured to expose each of the services to the host OS on a different port. To check the ports examine the output of `docker-compose ps`.
 
 ### Tests
 Tests are run automatically with `./gradlew build`. Even if the tests fail, the artifacts are built and can be run.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,21 @@ Because the Docker images are built automatically, a docker daemon must be avail
 There is a docker-compose environment included in this repository.
 This will spin up each of the services that make up the multi-int-store as well as any 3rd party services needed by the multi-int-store.
 
+A `cdr` network is needed to run via docker-compose. First, check if the `cdr` network is already created:
+```
+docker network ls
+```
+
+If it has not yet been created, execute:
+```
+docker network create --driver=overlay --attachable cdr
+```
+
+To check that it has been created successfully, execute:
+```
+docker network ls
+```
+
 To start the full environment, execute:
 ```
 docker-compose up -d

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To skip integration tests, add `-PskipITests`.
 	```
 	./gradlew run
 	```
-	
+
 ### Running via docker-compose
 There is a docker-compose environment included in this repository.
 This will spin up each of the services that make up the multi-int-store as well as any 3rd party services needed by the multi-int-store.
@@ -103,7 +103,9 @@ In order to make this flexible a variable has been added in the compose file tha
 
 To deploy to a swarm using a custom registry:
 1. re-tag and push images to custom registry
-2. Run 
+2. run `docker stack deploy -c <(REGISTRY=<registry-url> docker-compose config) cdr`
+
+
 ## Build Checks
 ### OWASP
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,8 @@ ext.skipIntegrationTests = {
 }
 
 repositories {
-	mavenCentral()
 	mavenLocal()
+	mavenCentral()
 }
 
 class SpotlessConfig {
@@ -141,8 +141,8 @@ subprojects {
 	}
 
 	repositories {
-		mavenCentral()
 		mavenLocal()
+		mavenCentral()
 	}
 
 	dependencies {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   ingest:
-    image: cnxta/cdr-ingest:0.1.0-SNAPSHOT
+    image: ${REGISTRY:-docker.io}/cnxta/cdr-ingest:0.1.0-SNAPSHOT
     hostname: cdr-ingest
     ports:
       - target: 8080
@@ -13,7 +13,7 @@ services:
       restart_policy:
         condition: any
   multi-int-store:
-    image: cnxta/cdr-multi-int-store:0.1.0-SNAPSHOT
+    image: ${REGISTRY:-docker.io}/cnxta/cdr-multi-int-store:0.1.0-SNAPSHOT
     hostname: cdr-store
     ports:
       - target: 8080
@@ -31,7 +31,7 @@ services:
       - "--cassandra.host=cassandra"
       - "--cassandra.port=9042"
   search:
-    image: cnxta/cdr-search:0.1.0-SNAPSHOT
+    image: ${REGISTRY:-docker.io}/cnxta/cdr-search:0.1.0-SNAPSHOT
     hostname: cdr-search
     ports:
       - target: 8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,10 @@
 version: '3.7'
 services:
   ingest:
-    image: ${REGISTRY}/cdr-ingest:0.1.0-SNAPSHOT
+    image: cnxta/cdr-ingest:0.1.0-SNAPSHOT
     hostname: cdr-ingest
     ports:
-      - target: 9040
+      - target: 8080
         published: 9040
         protocol: tcp
     networks:
@@ -13,10 +13,10 @@ services:
       restart_policy:
         condition: any
   multi-int-store:
-    image: ${REGISTRY}/cdr-multi-int-store:0.1.0-SNAPSHOT
+    image: cnxta/cdr-multi-int-store:0.1.0-SNAPSHOT
     hostname: cdr-store
     ports:
-      - target: 9041
+      - target: 8080
         published: 9041
         protocol: tcp
     networks:
@@ -26,18 +26,21 @@ services:
     deploy:
       restart_policy:
         condition: any
-#  search:
-#    image: ${REGISTRY}/cdr-multi-int-store:0.1.0-SNAPSHOT
-#    hostname: cdr-search
-#    ports:
-#      - target: 9039
-#        published: 9039
-#        protocol: tcp
-#    networks:
-#      - cdr
-#    deploy:
-#      restart_policy:
-#        condition: any
+    command:
+      - "--cassandra.host=cassandra"
+      - "--cassandra.port=9042"
+  search:
+    image: cnxta/cdr-search:0.1.0-SNAPSHOT
+    hostname: cdr-search
+    ports:
+      - target: 8080
+        published: 9039
+        protocol: tcp
+    networks:
+      - cdr
+    deploy:
+      restart_policy:
+        condition: any
   cassandra:
     image: cassandra
     hostname: cassandra

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - target: 8080
         published: 9041
         protocol: tcp
+    restart: on-failure
     networks:
       - cdr
     depends_on:

--- a/ingest/Dockerfile
+++ b/ingest/Dockerfile
@@ -1,11 +1,7 @@
 FROM openjdk:11-jre-slim
-VOLUME /tmp
+LABEL maintainer=connexta
+LABEL com.connexta.application.name=cdr-ingest
 ARG JAR_FILE
-COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java",\
-    "-Dserver.port=9040",\
-    "-Djava.security.egd=file:/dev/./urandom",\
-    "-Djava.rmi.server.hostname=cdr-ingest",\
-    "-jar",\
-    "/app.jar"]
-EXPOSE 9040
+COPY ${JAR_FILE} /cdr-ingest
+ENTRYPOINT ["/cdr-ingest"]
+EXPOSE 8080

--- a/ingest/build.gradle
+++ b/ingest/build.gradle
@@ -1,10 +1,17 @@
 plugins {
 	id "org.springframework.boot" version "2.1.5.RELEASE"
-	id "application"
+	id "com.palantir.docker" version "0.22.1"
 }
 
-application {
-	mainClassName = "com.connexta.ingest.IngestApplication"
+bootJar {
+	launchScript()
 }
 
-run.dependsOn(build)
+docker {
+	files tasks.bootJar.outputs
+	name "cnxta/cdr-ingest:${project.version}"
+	buildArgs([JAR_FILE: "${tasks.bootJar.outputs.files.singleFile.name}"])
+}
+
+build.dependsOn("docker")
+bootRun.dependsOn(build)

--- a/multi-int-store/Dockerfile
+++ b/multi-int-store/Dockerfile
@@ -1,11 +1,7 @@
 FROM openjdk:11-jre-slim
-VOLUME /tmp
+LABEL maintainer=connexta
+LABEL com.connexta.application.name=multi-int-store
 ARG JAR_FILE
-COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java",\
-    "-Dserver.port=9041",\
-    "-Djava.security.egd=file:/dev/./urandom",\
-    "-Djava.rmi.server.hostname=cdr-multi-int-store",\
-    "-jar",\
-    "/app.jar"]
-EXPOSE 9041
+COPY ${JAR_FILE} /multi-int-store
+ENTRYPOINT ["/multi-int-store"]
+EXPOSE 8080

--- a/multi-int-store/build.gradle
+++ b/multi-int-store/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id "org.springframework.boot" version "2.1.5.RELEASE"
-	id "application"
+	id "com.palantir.docker" version "0.22.1"
 }
 
 dependencies {
@@ -15,8 +15,14 @@ dependencies {
 	testImplementation "org.testcontainers:testcontainers:1.11.2"
 }
 
-application {
-	mainClassName = "com.connexta.multiintstore.MultiIntStoreApplication"
+bootJar {
+	launchScript()
 }
 
-run.dependsOn(build)
+docker {
+	files tasks.bootJar.outputs
+	name "cnxta/multi-int-store:${project.version}"
+	buildArgs([JAR_FILE: "${tasks.bootJar.outputs.files.singleFile.name}"])
+}
+
+build.dependsOn("docker")

--- a/multi-int-store/build.gradle
+++ b/multi-int-store/build.gradle
@@ -21,7 +21,7 @@ bootJar {
 
 docker {
 	files tasks.bootJar.outputs
-	name "cnxta/multi-int-store:${project.version}"
+	name "cnxta/cdr-multi-int-store:${project.version}"
 	buildArgs([JAR_FILE: "${tasks.bootJar.outputs.files.singleFile.name}"])
 }
 

--- a/search/Dockerfile
+++ b/search/Dockerfile
@@ -1,11 +1,7 @@
 FROM openjdk:11-jre-slim
-VOLUME /tmp
+LABEL maintainer=connexta
+LABEL com.connexta.application.name=cdr-search
 ARG JAR_FILE
-COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java",\
-    "-Dserver.port=9039",\
-    "-Djava.security.egd=file:/dev/./urandom",\
-    "-Djava.rmi.server.hostname=cdr-search",\
-    "-jar",\
-    "/app.jar"]
-EXPOSE 9039
+COPY ${JAR_FILE} /cdr-search
+ENTRYPOINT ["/cdr-search"]
+EXPOSE 8080

--- a/search/build.gradle
+++ b/search/build.gradle
@@ -1,10 +1,16 @@
 plugins {
 	id "org.springframework.boot" version "2.1.5.RELEASE"
-	id "application"
+	id "com.palantir.docker" version "0.22.1"
 }
 
-application {
-	mainClassName = "com.connexta.search.SearchApplication"
+bootJar {
+	launchScript()
 }
 
-run.dependsOn(build)
+docker {
+	files tasks.bootJar.outputs
+	name "cnxta/cdr-search:${project.version}"
+	buildArgs([JAR_FILE: "${tasks.bootJar.outputs.files.singleFile.name}"])
+}
+
+build.dependsOn("docker")


### PR DESCRIPTION
# Overview
* Removes application plugin from build.gradle files
* Configures the bootJar task to include the launch scripts
* Adds docker task
* Refactors/cleans up Dockerfiles
* Fixes up docker-compose file

# Details

## Docker Compose File
The main problem with the docker-compose file was that the `target` ports for each of the multi-int-store components were incorrect. The Dockerfiles had options built into them for `-Dserver.port=<integer>` that made it seem as though a custom port number was being used. there was nothing in place in the actual application to make use of this value however. Each of the spring-boot apps was actually binding 8080 within the docker containers. This meant that while docker was exposing the service on a custom port via the `published: 9041` for example, the target port was also 9041 _inside_ the container which was not a port that was bound by the app.

All the spring boot apps have been updated in the compose file to use `target: 8080`


## Gradle Build Changes
The three spring boot apps were configured in gradle to produce multiple outputs which weren't all necessary. This has been updated to just produce a single executable jar in all cases. This jar is a _true_ executable. This means that we don't need to do `java -jar <path to jar>`, instead we can name the file `cdr-ingest` (no .jar extension) for example and simply run ./cdr-ingest.

Additionally each docker image is now built automatically when running `./gradlew build` *This means that a docker daemon must be available to run the build*

# Testing
## Compose
* Build the project via `./gradlew build`
* Simply run `docker-compose up -d` to start all services in the background
* To check all services are up run `docker-compose ps`
* To tail the logs for all services run `docker-compose logs -f`
* To tail the logs for a subset of services run `docker-compose logs -f <serviceName> <serviceName>...`
* To clean up all services run `docker-compose down`

### Notes

The multi-int-store doesn't gracefully handle cases where cassandra isn't "ready" yet. To handle this I've added the `restart: on-failure` option to that service.


# Tasks
- [x] Add docker-compose details to README
- [ ] Add docker stack specific items