### PR TITLE
Added a retrieve endpoint

### DIFF
--- a/ingest/src/main/java/com/connexta/ingest/adaptors/Adaptor.java
+++ b/ingest/src/main/java/com/connexta/ingest/adaptors/Adaptor.java
@@ -7,9 +7,9 @@
 package com.connexta.ingest.adaptors;
 
 import com.connexta.ingest.service.api.IngestRequest;
-import java.util.UUID;
+import java.io.IOException;
 
 public interface Adaptor {
 
-  UUID upload(IngestRequest ingestRequest);
+  void upload(IngestRequest ingestRequest, String key) throws IOException;
 }

--- a/ingest/src/main/java/com/connexta/ingest/adaptors/StorageAdaptor.java
+++ b/ingest/src/main/java/com/connexta/ingest/adaptors/StorageAdaptor.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2019 Connexta, LLC
+ *
+ * Released under the GNU Lesser General Public License version 3; see
+ * https://www.gnu.org/licenses/lgpl-3.0.html
+ */
+package com.connexta.ingest.adaptors;
+
+import com.connexta.ingest.service.api.RetrieveResponse;
+import com.connexta.ingest.service.api.StoreRequest;
+import java.io.IOException;
+
+public interface StorageAdaptor {
+
+  void store(StoreRequest storeRequest, String key) throws IOException;
+
+  RetrieveResponse retrieve(String key) throws IOException;
+}

--- a/ingest/src/main/java/com/connexta/ingest/endpoint/IngestController.java
+++ b/ingest/src/main/java/com/connexta/ingest/endpoint/IngestController.java
@@ -11,19 +11,17 @@ import com.connexta.ingest.service.api.IngestService;
 import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController()
 public class IngestController implements IngestApi {
 
-  private final IngestService ingestService;
   private static Logger LOGGER = LoggerFactory.getLogger(IngestController.class);
+
+  private final IngestService ingestService;
 
   /**
    * Constructs a new REST Spring Web controller.
@@ -50,12 +48,5 @@ public class IngestController implements IngestApi {
       LOGGER.warn("Unable to ingest", e);
       return new ResponseEntity(HttpStatus.INTERNAL_SERVER_ERROR);
     }
-  }
-
-  @GetMapping("/retrieve/{ingestId}")
-  public ResponseEntity<Resource> retrieve(@PathVariable final String ingestId) {
-    LOGGER.info("Attempting to retrieve {}", ingestId);
-    // TODO don't use ingestService here
-    return ingestService.retrieve(ingestId);
   }
 }

--- a/ingest/src/main/java/com/connexta/ingest/endpoint/RetrieveController.java
+++ b/ingest/src/main/java/com/connexta/ingest/endpoint/RetrieveController.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2019 Connexta, LLC
+ *
+ * Released under the GNU Lesser General Public License version 3; see
+ * https://www.gnu.org/licenses/lgpl-3.0.html
+ */
+package com.connexta.ingest.endpoint;
+
+import com.connexta.ingest.service.api.RetrieveResponse;
+import com.connexta.ingest.service.api.RetrieveService;
+import java.io.IOException;
+import javax.validation.constraints.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+/** TODO move this out of the ingest app */
+@RestController()
+public class RetrieveController {
+
+  private static Logger LOGGER = LoggerFactory.getLogger(RetrieveController.class);
+
+  @NotNull private final RetrieveService retrieveService;
+
+  public RetrieveController(@NotNull RetrieveService retrieveService) {
+    this.retrieveService = retrieveService;
+  }
+
+  @GetMapping("/retrieve/{ingestId}")
+  public ResponseEntity<Resource> retrieve(@PathVariable final String ingestId) {
+    LOGGER.info("Attempting to retrieve {}", ingestId);
+
+    final RetrieveResponse retrieveResponse;
+
+    try {
+      retrieveResponse = retrieveService.retrieve(ingestId);
+    } catch (IOException e) {
+      LOGGER.warn("Unable to retrieve {}", ingestId, e);
+      return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    final Resource resource = retrieveResponse.getResource();
+    // TODO not sure if we need to set the filename in the header
+    return ResponseEntity.ok()
+        .contentType(retrieveResponse.getMediaType())
+        .header(
+            HttpHeaders.CONTENT_DISPOSITION,
+            "attachment; filename=\"" + resource.getFilename() + "\"")
+        .body(resource);
+  }
+}

--- a/ingest/src/main/java/com/connexta/ingest/service/api/IngestService.java
+++ b/ingest/src/main/java/com/connexta/ingest/service/api/IngestService.java
@@ -7,8 +7,6 @@
 package com.connexta.ingest.service.api;
 
 import java.io.IOException;
-import org.springframework.core.io.Resource;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.multipart.MultipartFile;
 
 /** Provides clients with a way to ingest Products into ION for processing and storage */
@@ -22,6 +20,4 @@ public interface IngestService {
       String title,
       String fileName)
       throws IOException;
-
-  ResponseEntity<Resource> retrieve(String ingestId);
 }

--- a/ingest/src/main/java/com/connexta/ingest/service/api/IngestService.java
+++ b/ingest/src/main/java/com/connexta/ingest/service/api/IngestService.java
@@ -6,17 +6,22 @@
  */
 package com.connexta.ingest.service.api;
 
-import java.util.UUID;
+import java.io.IOException;
+import org.springframework.core.io.Resource;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.multipart.MultipartFile;
 
 /** Provides clients with a way to ingest Products into ION for processing and storage */
 public interface IngestService {
 
-  UUID ingest(
+  void ingest(
       String acceptVersion,
       Long fileSize,
       String mimeType,
       MultipartFile file,
       String title,
-      String fileName);
+      String fileName)
+      throws IOException;
+
+  ResponseEntity<Resource> retrieve(String ingestId);
 }

--- a/ingest/src/main/java/com/connexta/ingest/service/api/RetrieveResponse.java
+++ b/ingest/src/main/java/com/connexta/ingest/service/api/RetrieveResponse.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2019 Connexta, LLC
+ *
+ * Released under the GNU Lesser General Public License version 3; see
+ * https://www.gnu.org/licenses/lgpl-3.0.html
+ */
+package com.connexta.ingest.service.api;
+
+import javax.validation.constraints.NotNull;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.Resource;
+import org.springframework.http.MediaType;
+
+@Getter
+public class RetrieveResponse {
+
+  @NotNull private final MediaType mediaType;
+  @NotNull private final Resource resource;
+
+  @Autowired
+  public RetrieveResponse(final MediaType mediaType, final Resource resource) {
+    this.mediaType = mediaType;
+    this.resource = resource;
+  }
+}

--- a/ingest/src/main/java/com/connexta/ingest/service/api/RetrieveService.java
+++ b/ingest/src/main/java/com/connexta/ingest/service/api/RetrieveService.java
@@ -4,12 +4,11 @@
  * Released under the GNU Lesser General Public License version 3; see
  * https://www.gnu.org/licenses/lgpl-3.0.html
  */
-package com.connexta.ingest.adaptors;
+package com.connexta.ingest.service.api;
 
-import com.connexta.ingest.service.api.IngestRequest;
 import java.io.IOException;
 
-public interface Adaptor {
+public interface RetrieveService {
 
-  void upload(IngestRequest ingestRequest, String key) throws IOException;
+  RetrieveResponse retrieve(String ingestId) throws IOException;
 }

--- a/ingest/src/main/java/com/connexta/ingest/service/api/StoreRequest.java
+++ b/ingest/src/main/java/com/connexta/ingest/service/api/StoreRequest.java
@@ -13,7 +13,7 @@ import org.springframework.web.multipart.MultipartFile;
 /** Java object representation of the ingest request */
 @Getter
 @AllArgsConstructor
-public class IngestRequest {
+public class StoreRequest {
   private final String acceptVersion;
   private final Long fileSize;
   private final String mimeType;

--- a/ingest/src/main/java/com/connexta/ingest/service/impl/IngestServiceImpl.java
+++ b/ingest/src/main/java/com/connexta/ingest/service/impl/IngestServiceImpl.java
@@ -6,29 +6,34 @@
  */
 package com.connexta.ingest.service.impl;
 
-import com.connexta.ingest.adaptors.S3Adaptor;
-import com.connexta.ingest.service.api.IngestRequest;
+import com.connexta.ingest.adaptors.S3StorageAdaptor;
 import com.connexta.ingest.service.api.IngestService;
+import com.connexta.ingest.service.api.StoreRequest;
 import com.connexta.ingest.transform.TransformClient;
 import com.connexta.transformation.rest.models.TransformRequest;
 import com.connexta.transformation.rest.models.TransformResponse;
 import java.io.IOException;
 import java.net.URL;
 import java.util.UUID;
-import lombok.AllArgsConstructor;
+import javax.validation.constraints.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.core.io.Resource;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
-@AllArgsConstructor
 public class IngestServiceImpl implements IngestService {
+
   private static final Logger LOGGER = LoggerFactory.getLogger(IngestServiceImpl.class);
-  private final S3Adaptor s3Adaptor;
-  private final TransformClient transformClient;
+
+  @NotNull private final S3StorageAdaptor s3Adaptor;
+  @NotNull private final TransformClient transformClient;
+
+  public IngestServiceImpl(
+      @NotNull final S3StorageAdaptor s3Adaptor, @NotNull final TransformClient transformClient) {
+    this.s3Adaptor = s3Adaptor;
+    this.transformClient = transformClient;
+  }
 
   @Override
   public void ingest(
@@ -40,9 +45,10 @@ public class IngestServiceImpl implements IngestService {
       String fileName)
       throws IOException {
     final String ingestId = UUID.randomUUID().toString().replace("-", "");
-    s3Adaptor.upload(
-        new IngestRequest(acceptVersion, fileSize, mimeType, file, title, fileName), ingestId);
+    s3Adaptor.store(
+        new StoreRequest(acceptVersion, fileSize, mimeType, file, title, fileName), ingestId);
 
+    // TODO get this URL programmatically
     final String url = new URL("TODO/retrieve/" + ingestId).toString();
     LOGGER.info("{} has been successfully stored in S3 and can be downloaded at {}", fileName, url);
 
@@ -57,12 +63,5 @@ public class IngestServiceImpl implements IngestService {
     final TransformResponse transformResponse = transformClient.requestTransform(transformRequest);
 
     LOGGER.warn("Completed transform request, response is {}", transformResponse);
-  }
-
-  @Override
-  public ResponseEntity<Resource> retrieve(final String ingestId) {
-    final ResponseEntity<Resource> resourceResponseEntity = s3Adaptor.retrieve(ingestId);
-    LOGGER.info("Resource \"{}\" has been successfully retrieved from S3", ingestId);
-    return resourceResponseEntity;
   }
 }

--- a/ingest/src/main/java/com/connexta/ingest/service/impl/RetrieveServiceImpl.java
+++ b/ingest/src/main/java/com/connexta/ingest/service/impl/RetrieveServiceImpl.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2019 Connexta, LLC
+ *
+ * Released under the GNU Lesser General Public License version 3; see
+ * https://www.gnu.org/licenses/lgpl-3.0.html
+ */
+package com.connexta.ingest.service.impl;
+
+import com.connexta.ingest.adaptors.S3StorageAdaptor;
+import com.connexta.ingest.service.api.RetrieveResponse;
+import com.connexta.ingest.service.api.RetrieveService;
+import java.io.IOException;
+import javax.validation.constraints.NotNull;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RetrieveServiceImpl implements RetrieveService {
+
+  @NotNull private final S3StorageAdaptor s3Adaptor;
+
+  public RetrieveServiceImpl(@NotNull final S3StorageAdaptor s3Adaptor) {
+    this.s3Adaptor = s3Adaptor;
+  }
+
+  @Override
+  public RetrieveResponse retrieve(final String ingestId) throws IOException {
+    return s3Adaptor.retrieve(ingestId);
+  }
+}

--- a/ingest/src/main/java/com/connexta/ingest/transform/TransformClient.java
+++ b/ingest/src/main/java/com/connexta/ingest/transform/TransformClient.java
@@ -31,7 +31,7 @@ public class TransformClient {
   @PostConstruct
   private void setEndpoint() throws URISyntaxException {
     // TODO: Set endpoint URL
-    setTransformEndpoint("http://TODO");
+    setTransformEndpoint("TODO/transform");
   }
 
   public TransformResponse requestTransform(TransformRequest transformRequest) {

--- a/ingest/src/test/java/com/connexta/ingest/IngestApplicationIntegrationTest.java
+++ b/ingest/src/test/java/com/connexta/ingest/IngestApplicationIntegrationTest.java
@@ -47,7 +47,7 @@ public class IngestApplicationIntegrationTest {
             multipart("/ingest")
                 .file("file", "some-content".getBytes())
                 .param("fileSize", "10")
-                .param("filename", "file")
+                .param("fileName", "file")
                 .param("title", "qualityTitle")
                 .param("mimeType", "plain/text")
                 .header("Accept-Version", "1.2.1")

--- a/multi-int-store/src/main/java/com/connexta/multiintstore/controllers/StorageController.java
+++ b/multi-int-store/src/main/java/com/connexta/multiintstore/controllers/StorageController.java
@@ -9,6 +9,8 @@ package com.connexta.multiintstore.controllers;
 import com.connexta.multiintstore.callbacks.CallbackValidator;
 import com.connexta.multiintstore.common.StorageManager;
 import com.fasterxml.jackson.databind.JsonNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class StorageController {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(StorageController.class);
   private final StorageManager manager;
   private final CallbackValidator validator = new CallbackValidator();
 
@@ -31,6 +34,7 @@ public class StorageController {
   @PostMapping(path = "/store/{ingestId}", consumes = "application/json")
   public ResponseEntity store(
       @PathVariable String ingestId, @RequestBody(required = false) JsonNode body) {
+    LOGGER.info("Received callback for ingestId {}", ingestId);
 
     Object callback = validator.parse(body);
 


### PR DESCRIPTION
You can can retrieve products from S3 with a new /retrieve/<ingestId> endpoint. The product should download as its original filename+extension. This works in the browser.