### PR TITLE
Updated search endpoint to return retrieve URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,11 +190,11 @@ controlled.
 Example configs/ingest_config.yml:
 ```yaml
 aws:
- s3:
-  endpointUrl: https://s3.us-west-1.amazonaws.com
-  region: us-west-1
-  bucket:
-   quarantine: ingest-quarantine
+  s3:
+    endpointUrl: https://s3.us-west-1.amazonaws.com
+    region: us-west-1
+    bucket:
+      quarantine: ingest-quarantine
 endpointUrl:
   transform: http://localhost:1231/transform/
   ingest:
@@ -205,6 +205,8 @@ endpointUrl:
 Example configs/mis_config.yml:
 ```yaml
 solr:
- host: localhost
- port: 9983
+  host: localhost
+  port: 9983
+endpointUrl:
+  retrieve: http://localhost:1233/retrieve/
 ```

--- a/ingest/src/main/java/com/connexta/ingest/service/impl/IngestServiceImpl.java
+++ b/ingest/src/main/java/com/connexta/ingest/service/impl/IngestServiceImpl.java
@@ -15,6 +15,7 @@ import com.connexta.transformation.rest.models.TransformResponse;
 import java.io.IOException;
 import java.net.URL;
 import java.util.UUID;
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,16 +30,20 @@ public class IngestServiceImpl implements IngestService {
 
   @NotNull private final S3StorageAdaptor s3Adaptor;
   @NotNull private final TransformClient transformClient;
-  private final String callbackEndpoint;
+  @NotEmpty private final String callbackEndpoint;
+  @NotEmpty private final String retrieveEndpoint;
 
   public IngestServiceImpl(
       @NotNull final S3StorageAdaptor s3Adaptor,
       @NotNull final TransformClient transformClient,
-      @Value("${endpointUrl.ingest.callback}") String callbackEndpoint) {
+      @NotEmpty @Value("${endpointUrl.ingest.callback}") final String callbackEndpoint,
+      @NotEmpty @Value("${endpointUrl.ingest.retrieve}") final String retrieveEndpoint) {
     this.s3Adaptor = s3Adaptor;
     this.transformClient = transformClient;
     this.callbackEndpoint = callbackEndpoint;
+    this.retrieveEndpoint = retrieveEndpoint;
     LOGGER.info("Multi-Int-Store Callback URL: {}", callbackEndpoint);
+    LOGGER.info("Retrieve URL: {}", retrieveEndpoint);
   }
 
   @Override
@@ -55,7 +60,7 @@ public class IngestServiceImpl implements IngestService {
         new StoreRequest(acceptVersion, fileSize, mimeType, file, title, fileName), ingestId);
 
     // TODO get this URL programmatically
-    final String url = new URL("TODO/retrieve/" + ingestId).toString();
+    final String url = new URL(retrieveEndpoint + ingestId).toString();
     LOGGER.info("{} has been successfully stored in S3 and can be downloaded at {}", fileName, url);
 
     final TransformRequest transformRequest = new TransformRequest();

--- a/multi-int-store/src/main/java/com/connexta/multiintstore/controllers/QueryController.java
+++ b/multi-int-store/src/main/java/com/connexta/multiintstore/controllers/QueryController.java
@@ -6,10 +6,15 @@
  */
 package com.connexta.multiintstore.controllers;
 
-import com.connexta.multiintstore.models.IndexedProductMetadata;
 import com.connexta.multiintstore.services.api.SearchService;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.List;
 import lombok.AllArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -21,11 +26,18 @@ import org.springframework.web.bind.annotation.RestController;
 @AllArgsConstructor
 public class QueryController {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(QueryController.class);
+
   private SearchService searchService;
 
   @RequestMapping(method = RequestMethod.GET, params = "q")
   @ResponseBody
-  public List<IndexedProductMetadata> searchKeyword(@RequestParam(value = "q") String keyword) {
-    return searchService.find(keyword);
+  public ResponseEntity<List<URL>> searchKeyword(@RequestParam(value = "q") String keyword) {
+    try {
+      return new ResponseEntity<>(searchService.find(keyword), HttpStatus.OK);
+    } catch (MalformedURLException e) {
+      LOGGER.warn("Unable to construct URLs when querying for {}", keyword, e);
+      return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
   }
 }

--- a/multi-int-store/src/main/java/com/connexta/multiintstore/services/api/SearchService.java
+++ b/multi-int-store/src/main/java/com/connexta/multiintstore/services/api/SearchService.java
@@ -7,11 +7,13 @@
 package com.connexta.multiintstore.services.api;
 
 import com.connexta.multiintstore.models.IndexedProductMetadata;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.List;
 
 public interface SearchService {
 
   void store(IndexedProductMetadata doc);
 
-  List<IndexedProductMetadata> find(String keyword);
+  List<URL> find(String keyword) throws MalformedURLException;
 }

--- a/multi-int-store/src/main/java/com/connexta/multiintstore/services/impl/SearchServiceImpl.java
+++ b/multi-int-store/src/main/java/com/connexta/multiintstore/services/impl/SearchServiceImpl.java
@@ -28,7 +28,7 @@ public class SearchServiceImpl implements SearchService {
 
   public SearchServiceImpl(
       @NotNull final IndexedMetadataRepository indexedMetadataRepository,
-      @NotEmpty @Value("${endpointUrl.ingest.retrieve}") final String retrieveEndpoint) {
+      @NotEmpty @Value("${endpointUrl.retrieve}") final String retrieveEndpoint) {
     this.indexedMetadataRepository = indexedMetadataRepository;
     this.retrieveEndpoint = retrieveEndpoint;
   }

--- a/multi-int-store/src/test/java/com/connexta/multiintstore/MultiIntStoreIntegrationTest.java
+++ b/multi-int-store/src/test/java/com/connexta/multiintstore/MultiIntStoreIntegrationTest.java
@@ -20,8 +20,6 @@ import com.xebialabs.restito.semantics.Condition;
 import com.xebialabs.restito.server.StubServer;
 import org.glassfish.grizzly.http.util.HttpStatus;
 import org.hamcrest.Matchers;
-import org.json.JSONArray;
-import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -104,7 +102,7 @@ public class MultiIntStoreIntegrationTest extends MultiIntStoreIntegrationTestCo
     mockMvc
         .perform(MockMvcRequestBuilders.get("/search?q=searchKeyword"))
         .andExpect(status().isOk())
-        .andExpect(content().json(new JSONArray().toString()));
+        .andExpect(content().string("[]"));
   }
 
   @Test
@@ -139,7 +137,7 @@ public class MultiIntStoreIntegrationTest extends MultiIntStoreIntegrationTestCo
     mockMvc
         .perform(MockMvcRequestBuilders.get("/search?q=thisKeywordDoesntMatchAnything"))
         .andExpect(status().isOk())
-        .andExpect(content().json(new JSONArray().toString()));
+        .andExpect(content().string("[]"));
   }
 
   @Test
@@ -174,11 +172,6 @@ public class MultiIntStoreIntegrationTest extends MultiIntStoreIntegrationTestCo
     mockMvc
         .perform(MockMvcRequestBuilders.get("/search?q=Winterfell"))
         .andExpect(status().isOk())
-        .andExpect(
-            content()
-                .json(
-                    new JSONArray()
-                        .put(new JSONObject().put("id", ingestId).put("contents", contents))
-                        .toString()));
+        .andExpect(content().string(String.format("[\"%s%s\"]", RETRIEVE_ENDPOINT, ingestId)));
   }
 }

--- a/multi-int-store/src/test/java/com/connexta/multiintstore/MultiIntStoreIntegrationTestContainers.java
+++ b/multi-int-store/src/test/java/com/connexta/multiintstore/MultiIntStoreIntegrationTestContainers.java
@@ -31,12 +31,16 @@ public abstract class MultiIntStoreIntegrationTestContainers {
           .withExposedPorts(8983)
           .waitingFor(Wait.forHttp("/solr/admin/cores?action=STATUS"));
 
+  protected static final String RETRIEVE_ENDPOINT = "http://localhost:9040/retrieve/";
+
   public static class Initializer
       implements ApplicationContextInitializer<ConfigurableApplicationContext> {
     @Override
     public void initialize(ConfigurableApplicationContext configurableApplicationContext) {
       TestPropertyValues.of(
-              "solr.host=" + solr.getContainerIpAddress(), "solr.port=" + solr.getMappedPort(8983))
+              "solr.host=" + solr.getContainerIpAddress(),
+              "solr.port=" + solr.getMappedPort(8983),
+              "endpointUrl.ingest.retrieve=" + RETRIEVE_ENDPOINT)
           .applyTo(configurableApplicationContext.getEnvironment());
     }
   }

--- a/multi-int-store/src/test/java/com/connexta/multiintstore/MultiIntStoreIntegrationTestContainers.java
+++ b/multi-int-store/src/test/java/com/connexta/multiintstore/MultiIntStoreIntegrationTestContainers.java
@@ -40,7 +40,7 @@ public abstract class MultiIntStoreIntegrationTestContainers {
       TestPropertyValues.of(
               "solr.host=" + solr.getContainerIpAddress(),
               "solr.port=" + solr.getMappedPort(8983),
-              "endpointUrl.ingest.retrieve=" + RETRIEVE_ENDPOINT)
+              "endpointUrl.retrieve=" + RETRIEVE_ENDPOINT)
           .applyTo(configurableApplicationContext.getEnvironment());
     }
   }


### PR DESCRIPTION
- Injected the retrieve endpoint into the ingest service
- Updated the /search endpoint to return a list of retrieve URLs instead of the id and cst