### PR TITLE
Upgrade org.owasp.dependencycheck version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
 
 plugins {
     id "java"
-    id "org.owasp.dependencycheck" version "5.0.0-M2"
+    id "org.owasp.dependencycheck" version "5.0.0"
     id "com.diffplug.gradle.spotless" version "3.20.0"
     id "org.sonarqube" version "2.7"
 }

--- a/buildSrc/src/main/groovy/Dependencies.groovy
+++ b/buildSrc/src/main/groovy/Dependencies.groovy
@@ -22,6 +22,7 @@ class Dependencies {
   static def tomcatCore = { it=Versions.tomcat -> "org.apache.tomcat.embed:tomcat-embed-core:${it}" }
   static def tomcatWebsocket = { it=Versions.tomcat -> "org.apache.tomcat.embed:tomcat-embed-websocket:${it}" }
   static def transformAPI = { it=Versions.transformAPI -> "com.connexta.transformation:transformation-api-rest-spring-stubs:${it}" }
+  static def zookeeper = { it=Versions.zookeeper -> "org.apache.zookeeper:zookeeper:${it}" }
 
   //  Test Dependencies
   static def hamcrestOptionals = { it=Versions.hamcrest -> "com.github.npathai:hamcrest-optional:${it}" }

--- a/buildSrc/src/main/groovy/Versions.groovy
+++ b/buildSrc/src/main/groovy/Versions.groovy
@@ -19,7 +19,7 @@ class Versions {
     static String json = "20180813"
     static String lombok = "1.18.6"
     static String springBoot = "2.1.5.RELEASE"
-    static String springData = "4.0.8.RELEASE"
+    static String springData = "4.0.9.RELEASE"
     static String tomcat = "9.0.19"
     static String transformAPI = "0.0.1-SNAPSHOT"
 

--- a/buildSrc/src/main/groovy/Versions.groovy
+++ b/buildSrc/src/main/groovy/Versions.groovy
@@ -22,6 +22,7 @@ class Versions {
     static String springData = "4.0.9.RELEASE"
     static String tomcat = "9.0.19"
     static String transformAPI = "0.0.1-SNAPSHOT"
+    static String zookeeper = "3.5.5"
 
     //  Test Versions
     static String hamcrest = "2.0.0"

--- a/multi-int-store/build.gradle
+++ b/multi-int-store/build.gradle
@@ -8,6 +8,10 @@
 
 dependencies {
     implementation(Dependencies.springFrameworkSolr())
+    implementation(Dependencies.zookeeper()) {
+        force = true
+        because "Zookeeper 3.4.14 is a transitive dependency of org.springframework.data:spring-data-solr:4.0.9.RELEASE and is affected by CVE-2019-0232."
+    }
     implementation(Dependencies.guava()) {
         because "CVE-2018-10237 in guava 19.0"
     }


### PR DESCRIPTION
5.0.0 of org.owasp.dependencycheck was released on June 9: https://plugins.gradle.org/plugin/org.owasp.dependencycheck/5.0.0.