### PR TITLE
Add simple error handling for transformation service errors

### DIFF
--- a/ingest/src/main/java/com/connexta/ingest/config/ApplicationConfiguration.java
+++ b/ingest/src/main/java/com/connexta/ingest/config/ApplicationConfiguration.java
@@ -11,6 +11,7 @@ import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.web.client.DefaultResponseErrorHandler;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
@@ -19,6 +20,6 @@ import org.springframework.web.client.RestTemplate;
 public class ApplicationConfiguration {
   @Bean
   public RestTemplate restTemplate(RestTemplateBuilder builder) {
-    return builder.build();
+    return builder.errorHandler(new DefaultResponseErrorHandler()).build();
   }
 }

--- a/ingest/src/main/java/com/connexta/ingest/endpoint/IngestController.java
+++ b/ingest/src/main/java/com/connexta/ingest/endpoint/IngestController.java
@@ -7,6 +7,7 @@
 package com.connexta.ingest.endpoint;
 
 import com.connexta.ingest.exceptions.StorageException;
+import com.connexta.ingest.exceptions.TransformException;
 import com.connexta.ingest.rest.spring.IngestApi;
 import com.connexta.ingest.service.api.IngestService;
 import java.io.IOException;
@@ -45,7 +46,7 @@ public class IngestController implements IngestApi {
     try {
       ingestService.ingest(acceptVersion, fileSize, mimeType, file, title, fileName);
       return new ResponseEntity(HttpStatus.ACCEPTED);
-    } catch (IOException | StorageException e) {
+    } catch (IOException | StorageException | TransformException e) {
       LOGGER.warn("Unable to ingest", e);
       return new ResponseEntity(HttpStatus.INTERNAL_SERVER_ERROR);
     }

--- a/ingest/src/main/java/com/connexta/ingest/exceptions/TransformException.java
+++ b/ingest/src/main/java/com/connexta/ingest/exceptions/TransformException.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2019 Connexta, LLC
+ *
+ * Released under the GNU Lesser General Public License version 3; see
+ * https://www.gnu.org/licenses/lgpl-3.0.html
+ */
+package com.connexta.ingest.exceptions;
+
+public class TransformException extends Exception {}

--- a/ingest/src/main/java/com/connexta/ingest/service/api/IngestService.java
+++ b/ingest/src/main/java/com/connexta/ingest/service/api/IngestService.java
@@ -7,6 +7,7 @@
 package com.connexta.ingest.service.api;
 
 import com.connexta.ingest.exceptions.StorageException;
+import com.connexta.ingest.exceptions.TransformException;
 import java.io.IOException;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -20,5 +21,5 @@ public interface IngestService {
       MultipartFile file,
       String title,
       String fileName)
-      throws IOException, StorageException;
+      throws IOException, StorageException, TransformException;
 }

--- a/ingest/src/test/java/com/connexta/ingest/TestUtilConfig.java
+++ b/ingest/src/test/java/com/connexta/ingest/TestUtilConfig.java
@@ -12,6 +12,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
+import org.springframework.web.client.DefaultResponseErrorHandler;
 import org.springframework.web.client.RestTemplate;
 import software.amazon.awssdk.services.s3.S3Client;
 
@@ -32,6 +33,6 @@ public class TestUtilConfig {
 
   @Bean
   public RestTemplate restTemplate(RestTemplateBuilder builder) {
-    return Mockito.mock(RestTemplate.class);
+    return builder.errorHandler(new DefaultResponseErrorHandler()).build();
   }
 }


### PR DESCRIPTION
If any exception is thrown when communicating via the rest template, throw an error and return that back to the caller of /ingest . 
Implement retry logic at a later time. 