### PR TITLE
Cleaned up dependencies now that not every subproject is a spring-boot app

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -167,27 +167,11 @@ subprojects {
     }
 
     dependencies {
-        implementation(Dependencies.springBootWebStarter())
-        implementation(Dependencies.jacksonDatabind()) {
-            force = true
-            because "CVE-2019-12086 is contained within 2.9.8 the version Spring-Web 2.1.5 uses"
-        }
-        implementation(Dependencies.tomcatWebsocket()) {
-            force = true
-            because "CVE-2019-0232 in the transitive tomcat-embed-websocket dependency"
-        }
-        implementation(Dependencies.tomcatCore()) {
-            force = true
-            because "CVE-2019-0232 in the transitive tomcat-embed-core dependency"
-        }
-
         compileOnly(Dependencies.lombok())
         annotationProcessor(Dependencies.lombok())
 
-        //  Test Dependencies :
-        testImplementation(Dependencies.springBootTestStarter())
-        testCompile(Dependencies.junit())
-        // required if you want to use Mockito for unit tests
+        //  Test Dependencies
+        testImplementation(Dependencies.junit())
         testImplementation(Dependencies.mockito())
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,10 @@ subprojects {
         failBuildOnCVSS = 4
         failOnError = true
 
+        analyzers {
+            ossIndexEnabled = false
+        }
+
         // Add support for NVD mirror
         if (project.hasProperty("dependencyCheckUrlModified") && project.hasProperty("dependencyCheckUrlBase")) {
             println "Using NVD Mirrors: ${dependencyCheckUrlBase} and ${dependencyCheckUrlModified}"

--- a/buildSrc/src/main/groovy/Dependencies.groovy
+++ b/buildSrc/src/main/groovy/Dependencies.groovy
@@ -8,31 +8,26 @@
 class Dependencies {
 
   //  Dependencies
-  static def awsBom = { it=Versions.aws -> "software.amazon.awssdk:bom:${it}" }
   static def awsS3 = { it=Versions.aws -> "software.amazon.awssdk:s3:${it}" }
-  static def commonsIO = { it=Versions.commonsIO -> "commons-io:commons-io:${it}" }
-  static def guava = { it=Versions.guava -> "com.google.guava:guava:${it}" }
-  static def ingestAPI = { it=Versions.ingestAPI -> "com.connexta.ingest:ingest-api-rest-spring-stubs:${it}" }
-  static def jacksonDatabind = { it=Versions.jacksonCore -> "com.fasterxml.jackson.core:jackson-databind:${it}" }
-  static def json = { it=Versions.json -> "org.json:json:${it}" }
   static def lombok = { it=Versions.lombok -> "org.projectlombok:lombok:${it}" }
-  static def springBootWebfluxStarter = { it=Versions.springBoot -> "org.springframework.boot:spring-boot-starter-webflux:${it}" }
-  static def springBootWebStarter = { it=Versions.springBoot -> "org.springframework.boot:spring-boot-starter-web:${it}" }
-  static def springFrameworkSolr = { it=Versions.springData -> "org.springframework.data:spring-data-solr:${it}" }
-  static def tomcatCore = { it=Versions.tomcat -> "org.apache.tomcat.embed:tomcat-embed-core:${it}" }
-  static def tomcatWebsocket = { it=Versions.tomcat -> "org.apache.tomcat.embed:tomcat-embed-websocket:${it}" }
+  static def commonsIO = { it=Versions.commonsIO -> "commons-io:commons-io:${it}" }
+  static def ingestAPI = { it=Versions.ingestAPI -> "com.connexta.ingest:ingest-api-rest-spring-stubs:${it}" }
+  static def springBootStarterWeb = { it=Versions.springBoot -> "org.springframework.boot:spring-boot-starter-web:${it}" }
+  static def springDataSolr = { it=Versions.springData -> "org.springframework.data:spring-data-solr:${it}" }
   static def transformAPI = { it=Versions.transformAPI -> "com.connexta.transformation:transformation-api-rest-spring-stubs:${it}" }
-  static def zookeeper = { it=Versions.zookeeper -> "org.apache.zookeeper:zookeeper:${it}" }
 
   //  Test Dependencies
-  static def hamcrestOptionals = { it=Versions.hamcrest -> "com.github.npathai:hamcrest-optional:${it}" }
+  static def hamcrestOptional = { it=Versions.npathai -> "com.github.npathai:hamcrest-optional:${it}" }
   static def junit = { it=Versions.junit -> "junit:junit:${it}" }
   static def mockito = { it= Versions.mockito -> "org.mockito:mockito-core:${it}" }
+  static def springBootStarterTest = { it=Versions.springBoot -> "org.springframework.boot:spring-boot-starter-test:${it}" }
   static def restito = { it=Versions.restito -> "com.xebialabs.restito:restito:${it}" }
-  static def springBootTestStarter = { it=Versions.springBoot -> "org.springframework.boot:spring-boot-starter-test:${it}" }
   static def testContainers = { it=Versions.testContainers -> "org.testcontainers:testcontainers:${it}" }
 
   //  Plugin Dependencies
   static def palantir = { it=Versions.palantir -> "gradle.plugin.com.palantir.gradle.docker:gradle-docker:${it}" }
   static def springBootGradlePlugin = { it=Versions.springBoot -> "org.springframework.boot:spring-boot-gradle-plugin:${it}" }
+
+  // OWASP Override Transitive Dependencies
+  static def zookeeper = { it=Versions.zookeeper -> "org.apache.zookeeper:zookeeper:${it}" }
 }

--- a/buildSrc/src/main/groovy/Dependencies.groovy
+++ b/buildSrc/src/main/groovy/Dependencies.groovy
@@ -9,9 +9,9 @@ class Dependencies {
 
   //  Dependencies
   static def awsS3 = { it=Versions.aws -> "software.amazon.awssdk:s3:${it}" }
-  static def lombok = { it=Versions.lombok -> "org.projectlombok:lombok:${it}" }
   static def commonsIO = { it=Versions.commonsIO -> "commons-io:commons-io:${it}" }
   static def ingestAPI = { it=Versions.ingestAPI -> "com.connexta.ingest:ingest-api-rest-spring-stubs:${it}" }
+  static def lombok = { it=Versions.lombok -> "org.projectlombok:lombok:${it}" }
   static def springBootStarterWeb = { it=Versions.springBoot -> "org.springframework.boot:spring-boot-starter-web:${it}" }
   static def springDataSolr = { it=Versions.springData -> "org.springframework.data:spring-data-solr:${it}" }
   static def transformAPI = { it=Versions.transformAPI -> "com.connexta.transformation:transformation-api-rest-spring-stubs:${it}" }
@@ -20,8 +20,8 @@ class Dependencies {
   static def hamcrestOptional = { it=Versions.npathai -> "com.github.npathai:hamcrest-optional:${it}" }
   static def junit = { it=Versions.junit -> "junit:junit:${it}" }
   static def mockito = { it= Versions.mockito -> "org.mockito:mockito-core:${it}" }
-  static def springBootStarterTest = { it=Versions.springBoot -> "org.springframework.boot:spring-boot-starter-test:${it}" }
   static def restito = { it=Versions.restito -> "com.xebialabs.restito:restito:${it}" }
+  static def springBootStarterTest = { it=Versions.springBoot -> "org.springframework.boot:spring-boot-starter-test:${it}" }
   static def testContainers = { it=Versions.testContainers -> "org.testcontainers:testcontainers:${it}" }
 
   //  Plugin Dependencies

--- a/buildSrc/src/main/groovy/Versions.groovy
+++ b/buildSrc/src/main/groovy/Versions.groovy
@@ -11,27 +11,24 @@ class Versions {
     static String project = "0.1.0-SNAPSHOT"
 
     //  Versions
-    static String aws = "2.5.67"
+    static String aws = "2.5.69"
     static String commonsIO = "2.6"
-    static String guava = "28.0-jre"
     static String ingestAPI = "0.1.1"
-    static String jacksonCore = "2.9.9"
-    static String json = "20180813"
     static String lombok = "1.18.8"
     static String springBoot = "2.1.6.RELEASE"
     static String springData = "4.0.9.RELEASE"
-    static String tomcat = "9.0.21"
     static String transformAPI = "0.0.1-SNAPSHOT"
-    static String zookeeper = "3.5.5"
 
     //  Test Versions
-    static String hamcrest = "2.0.0"
     static String junit = "4.12"
     static String mockito = "2.28.2"
+    static String npathai = "2.0.0"
     static String restito = "0.9.3"
     static String testContainers = "1.11.3"
 
     //  Plugin Versions
     static String palantir = "0.22.1"
 
+    // OWASP Override Versions
+    static String zookeeper = "3.5.5"
 }

--- a/ingest/build.gradle
+++ b/ingest/build.gradle
@@ -9,6 +9,12 @@ plugins {
     id "org.springframework.boot"
 }
 
+configurations {
+    implementation {
+        exclude group: "org.jdom", module: "jdom" // CVE-2019-12814
+    }
+}
+
 dependencies {
     implementation(Dependencies.springBootStarterWeb())
     implementation(Dependencies.commonsIO())

--- a/ingest/build.gradle
+++ b/ingest/build.gradle
@@ -10,14 +10,13 @@ plugins {
 }
 
 dependencies {
-    implementation(Dependencies.json())
+    implementation(Dependencies.springBootStarterWeb())
     implementation(Dependencies.commonsIO())
     implementation(Dependencies.ingestAPI())
     implementation(Dependencies.transformAPI())
     implementation(Dependencies.awsS3())
-    implementation platform((Dependencies.awsBom()))
     implementation project(":retrieve-api")
-    testImplementation(Dependencies.springBootTestStarter())
+    testImplementation(Dependencies.springBootStarterTest())
 }
 
 dependencyCheck {

--- a/ingest/owasp-suppressions.xml
+++ b/ingest/owasp-suppressions.xml
@@ -17,4 +17,12 @@
         <cpe>cpe:/a:gradle:gradle</cpe>
         <cve>CVE-2019-11065</cve>
     </suppress>
+    <suppress>
+        <!-- Only present when JDOM 1.x or 2.x jar is in the classpath. JDOM has been excluded. -->
+        <notes><![CDATA[
+        file name: jackson-databind-2.9.9.jar
+        ]]></notes>
+        <gav regex="true">^com\.fasterxml\.jackson\.core:jackson-databind:.*$</gav>
+        <cve>CVE-2019-12814</cve>
+    </suppress>
 </suppressions>

--- a/multi-int-store/build.gradle
+++ b/multi-int-store/build.gradle
@@ -10,18 +10,16 @@ plugins {
 }
 
 dependencies {
-    implementation(Dependencies.springFrameworkSolr())
+    implementation(Dependencies.springBootStarterWeb())
     implementation(Dependencies.zookeeper()) {
         force = true
         because "Zookeeper 3.4.14 is a transitive dependency of org.springframework.data:spring-data-solr:4.0.9.RELEASE and is affected by CVE-2019-0232."
     }
-    implementation(Dependencies.guava()) {
-        because "CVE-2018-10237 in guava 19.0"
-    }
-    implementation(Dependencies.springBootWebfluxStarter())
+    implementation(Dependencies.springDataSolr())
+    testImplementation(Dependencies.springBootStarterTest())
     testImplementation(Dependencies.testContainers())
     testImplementation(Dependencies.restito())
-    testImplementation(Dependencies.hamcrestOptionals())
+    testImplementation(Dependencies.hamcrestOptional())
 }
 
 bootJar {

--- a/multi-int-store/build.gradle
+++ b/multi-int-store/build.gradle
@@ -9,6 +9,12 @@ plugins {
     id "org.springframework.boot"
 }
 
+configurations {
+    implementation {
+        exclude group: "org.jdom", module: "jdom" // CVE-2019-12814
+    }
+}
+
 dependencies {
     implementation(Dependencies.springBootStarterWeb())
     implementation(Dependencies.zookeeper()) {
@@ -20,6 +26,10 @@ dependencies {
     testImplementation(Dependencies.testContainers())
     testImplementation(Dependencies.restito())
     testImplementation(Dependencies.hamcrestOptional())
+}
+
+dependencyCheck {
+    suppressionFile = "${projectDir}/owasp-suppressions.xml"
 }
 
 bootJar {

--- a/multi-int-store/owasp-suppressions.xml
+++ b/multi-int-store/owasp-suppressions.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd">
+    <suppress>
+        <!-- Only present when JDOM 1.x or 2.x jar is in the classpath. JDOM has been excluded. -->
+        <notes><![CDATA[
+        file name: jackson-databind-2.9.9.jar
+        ]]></notes>
+        <gav regex="true">^com\.fasterxml\.jackson\.core:jackson-databind:.*$</gav>
+        <cve>CVE-2019-12814</cve>
+    </suppress>
+</suppressions>

--- a/retrieve-api/build.gradle
+++ b/retrieve-api/build.gradle
@@ -6,6 +6,16 @@
  */
 /* Build Script */
 
+configurations {
+    implementation {
+        exclude group: "org.jdom", module: "jdom" // CVE-2019-12814
+    }
+}
+
 dependencies {
     implementation(Dependencies.springBootStarterWeb())
+}
+
+dependencyCheck {
+    suppressionFile = "${projectDir}/owasp-suppressions.xml"
 }

--- a/retrieve-api/build.gradle
+++ b/retrieve-api/build.gradle
@@ -7,5 +7,5 @@
 /* Build Script */
 
 dependencies {
-    implementation(Dependencies.springBootWebStarter())
+    implementation(Dependencies.springBootStarterWeb())
 }

--- a/retrieve-api/owasp-suppressions.xml
+++ b/retrieve-api/owasp-suppressions.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd">
+    <suppress>
+        <!-- Only present when JDOM 1.x or 2.x jar is in the classpath. JDOM has been excluded. -->
+        <notes><![CDATA[
+        file name: jackson-databind-2.9.9.jar
+        ]]></notes>
+        <gav regex="true">^com\.fasterxml\.jackson\.core:jackson-databind:.*$</gav>
+        <cve>CVE-2019-12814</cve>
+    </suppress>
+</suppressions>

--- a/search/build.gradle
+++ b/search/build.gradle
@@ -9,8 +9,18 @@ plugins {
     id "org.springframework.boot"
 }
 
+configurations {
+    implementation {
+        exclude group: "org.jdom", module: "jdom" // CVE-2019-12814
+    }
+}
+
 dependencies {
     implementation(Dependencies.springBootStarterWeb())
+}
+
+dependencyCheck {
+    suppressionFile = "${projectDir}/owasp-suppressions.xml"
 }
 
 bootJar {

--- a/search/build.gradle
+++ b/search/build.gradle
@@ -9,6 +9,10 @@ plugins {
     id "org.springframework.boot"
 }
 
+dependencies {
+    implementation(Dependencies.springBootStarterWeb())
+}
+
 bootJar {
     launchScript()
 }

--- a/search/owasp-suppressions.xml
+++ b/search/owasp-suppressions.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd">
+    <suppress>
+        <!-- Only present when JDOM 1.x or 2.x jar is in the classpath. JDOM has been excluded. -->
+        <notes><![CDATA[
+        file name: jackson-databind-2.9.9.jar
+        ]]></notes>
+        <gav regex="true">^com\.fasterxml\.jackson\.core:jackson-databind:.*$</gav>
+        <cve>CVE-2019-12814</cve>
+    </suppress>
+</suppressions>


### PR DESCRIPTION
https://github.com/connexta/multi-int-store/pull/63 updated the build.gradle files so that not every project must be a spring-boot app. However, some dependencies were missed in the move. This PR addresses those and also does some general clean up, including OWASP mitigations that are no longer necessary after recent version upgrades.