### PR TITLE
Also exclude jdom2 to address CVE-2019-12814

### DIFF
--- a/ingest/build.gradle
+++ b/ingest/build.gradle
@@ -11,7 +11,7 @@ plugins {
 
 configurations {
     implementation {
-        exclude group: "org.jdom", module: "jdom" // CVE-2019-12814
+        exclude group: "org.jdom" // CVE-2019-12814
     }
 }
 

--- a/multi-int-store/build.gradle
+++ b/multi-int-store/build.gradle
@@ -11,7 +11,7 @@ plugins {
 
 configurations {
     implementation {
-        exclude group: "org.jdom", module: "jdom" // CVE-2019-12814
+        exclude group: "org.jdom" // CVE-2019-12814
     }
 }
 

--- a/retrieve-api/build.gradle
+++ b/retrieve-api/build.gradle
@@ -8,7 +8,7 @@
 
 configurations {
     implementation {
-        exclude group: "org.jdom", module: "jdom" // CVE-2019-12814
+        exclude group: "org.jdom" // CVE-2019-12814
     }
 }
 

--- a/search/build.gradle
+++ b/search/build.gradle
@@ -11,7 +11,7 @@ plugins {
 
 configurations {
     implementation {
-        exclude group: "org.jdom", module: "jdom" // CVE-2019-12814
+        exclude group: "org.jdom" // CVE-2019-12814
     }
 }
 


### PR DESCRIPTION
I realized after I merged https://github.com/connexta/multi-int-store/pull/66 that JDOM 2.x has a different module name than JDOM 1.x. This PR updates the configuration to exclude JDOM 2.x as well to prevent CVE-2019-12814.

https://nvd.nist.gov/vuln/detail/CVE-2019-12814
https://mvnrepository.com/artifact/org.jdom