### PR TITLE
Fixed and unignored some ingest itests

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,8 +193,7 @@ Example configs/ingest_config.yml:
 endpointUrl:
   store: http://localhost:1232/store/
   transform: http://localhost:1231/transform/
-  ingest:
-    retrieve: http://localhost:1233/retrieve/
+  retrieve: http://localhost:1233/retrieve/
 ```
 
 Example configs/mis_config.yml:

--- a/ingest/src/main/java/com/connexta/ingest/service/impl/IngestServiceImpl.java
+++ b/ingest/src/main/java/com/connexta/ingest/service/impl/IngestServiceImpl.java
@@ -36,7 +36,7 @@ public class IngestServiceImpl implements IngestService {
   public IngestServiceImpl(
       @NotNull final TransformClient transformClient,
       @NotEmpty @Value("${endpointUrl.store}") final String callbackEndpoint,
-      @NotEmpty @Value("${endpointUrl.ingest.retrieve}") final String retrieveEndpoint) {
+      @NotEmpty @Value("${endpointUrl.retrieve}") final String retrieveEndpoint) {
     this.transformClient = transformClient;
     this.callbackEndpoint = callbackEndpoint;
     this.retrieveEndpoint = retrieveEndpoint;

--- a/ingest/src/test/java/com/connexta/ingest/IngestApplicationIntegrationTest.java
+++ b/ingest/src/test/java/com/connexta/ingest/IngestApplicationIntegrationTest.java
@@ -38,6 +38,7 @@ public class IngestApplicationIntegrationTest {
 
   private static final byte[] TEST_FILE = "some-content".getBytes();
   private static final int TEST_FILE_SIZE = TEST_FILE.length;
+  private static final String ENDPOINT_URL_TRANSFORM = "https://localhost/transform";
 
   @Autowired private RestTemplate restTemplate;
 
@@ -59,14 +60,13 @@ public class IngestApplicationIntegrationTest {
   }
 
   @Test
-  @Ignore
   public void testContextLoads() {}
 
   @Test
   @Ignore
-  public void testSuccessfulTransformRequest() throws Exception {
+  public void testSuccessfulIngestRequest() throws Exception {
     server
-        .expect(requestTo("https://localhost/transform"))
+        .expect(requestTo(ENDPOINT_URL_TRANSFORM))
         .andRespond(
             withStatus(HttpStatus.ACCEPTED)
                 .contentType(MediaType.APPLICATION_JSON)
@@ -89,13 +89,19 @@ public class IngestApplicationIntegrationTest {
         .andExpect(status().isAccepted());
   }
 
+  @Test
+  @Ignore
+  public void testUnsuccessfulStoreRequest() {
+    // TODO
+  }
+
   // The error handler throws the same exception for all non-202 status codes returned by the
   // transformation endpoint
   @Test
   @Ignore
-  public void testUnsuccessfulRequest() throws Exception {
+  public void testUnsuccessfulTransformRequest() throws Exception {
     server
-        .expect(requestTo("https://localhost/transform"))
+        .expect(requestTo(ENDPOINT_URL_TRANSFORM))
         .andRespond(
             withStatus(HttpStatus.BAD_REQUEST)
                 .contentType(MediaType.APPLICATION_JSON)
@@ -118,7 +124,6 @@ public class IngestApplicationIntegrationTest {
         .andExpect(status().isInternalServerError());
   }
 
-  @Ignore
   @Test
   public void testIncorrectlyFormattedIngestRequest() throws Exception {
     mvc.perform(
@@ -134,7 +139,6 @@ public class IngestApplicationIntegrationTest {
   }
 
   @Test
-  @Ignore
   public void testIngestRequestFileSizeMismatch() throws Exception {
     mvc.perform(
             multipart("/ingest")

--- a/ingest/src/test/resources/application.yml
+++ b/ingest/src/test/resources/application.yml
@@ -1,5 +1,5 @@
 # Todo: Update these placeholders when we add tests that use them.
 endpointUrl:
+  store: https://localhost/store
   transform: https://localhost/transform
-  ingest:
-    retrieve: https://change.me
+  retrieve: https://localhost/retrieve


### PR DESCRIPTION
and renamed `endpointUrl.ingest.retrieve` to `endpointUrl.retrieve`