### PR TITLE
Contain MultipartFile to only the REST endpoints

### DIFF
--- a/ingest/src/main/java/com/connexta/ingest/endpoint/IngestController.java
+++ b/ingest/src/main/java/com/connexta/ingest/endpoint/IngestController.java
@@ -10,6 +10,7 @@ import com.connexta.ingest.exceptions.StoreException;
 import com.connexta.ingest.exceptions.TransformException;
 import com.connexta.ingest.rest.spring.IngestApi;
 import com.connexta.ingest.service.api.IngestService;
+import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -55,7 +56,7 @@ public class IngestController implements IngestApi {
     }
 
     try {
-      ingestService.ingest(fileSize, mimeType, file, fileName);
+      ingestService.ingest(fileSize, mimeType, file.getInputStream(), fileName);
     } catch (StoreException | TransformException e) {
       LOGGER.warn(
           "Unable to complete ingest request with params acceptVersion={}, fileSize={}, mimeType={}, title={}, fileName={}",
@@ -65,7 +66,17 @@ public class IngestController implements IngestApi {
           title,
           fileName,
           e);
-      return new ResponseEntity(HttpStatus.INTERNAL_SERVER_ERROR);
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+    } catch (IOException e) {
+      LOGGER.warn(
+          "Unable to read file for ingest request with params acceptVersion={}, fileSize={}, mimeType={}, title={}, fileName={}",
+          acceptVersion,
+          fileSize,
+          mimeType,
+          title,
+          fileName,
+          e);
+      return ResponseEntity.badRequest().build();
     }
 
     return ResponseEntity.accepted().build();

--- a/ingest/src/main/java/com/connexta/ingest/service/api/IngestService.java
+++ b/ingest/src/main/java/com/connexta/ingest/service/api/IngestService.java
@@ -8,11 +8,11 @@ package com.connexta.ingest.service.api;
 
 import com.connexta.ingest.exceptions.StoreException;
 import com.connexta.ingest.exceptions.TransformException;
+import java.io.InputStream;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
-import org.springframework.web.multipart.MultipartFile;
 
 /** Provides clients with a way to ingest Products into ION for processing and storage */
 public interface IngestService {
@@ -20,7 +20,7 @@ public interface IngestService {
   void ingest(
       @NotNull @Min(1L) @Max(10737418240L) final Long fileSize,
       @NotEmpty final String mimeType,
-      @NotNull final MultipartFile file,
+      @NotNull final InputStream inputStream,
       @NotEmpty final String fileName)
       throws StoreException, TransformException;
 }

--- a/ingest/src/main/java/com/connexta/ingest/service/impl/IngestServiceImpl.java
+++ b/ingest/src/main/java/com/connexta/ingest/service/impl/IngestServiceImpl.java
@@ -11,6 +11,7 @@ import com.connexta.ingest.client.TransformClient;
 import com.connexta.ingest.exceptions.StoreException;
 import com.connexta.ingest.exceptions.TransformException;
 import com.connexta.ingest.service.api.IngestService;
+import java.io.InputStream;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
@@ -18,7 +19,6 @@ import javax.validation.constraints.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 
 @Service
 public class IngestServiceImpl implements IngestService {
@@ -38,10 +38,10 @@ public class IngestServiceImpl implements IngestService {
   public void ingest(
       @NotNull @Min(1L) @Max(10737418240L) final Long fileSize,
       @NotEmpty final String mimeType,
-      @NotNull final MultipartFile file,
+      @NotNull final InputStream inputStream,
       @NotEmpty final String fileName)
       throws StoreException, TransformException {
-    final String location = storeClient.store(fileSize, mimeType, file, fileName).toString();
+    final String location = storeClient.store(fileSize, mimeType, inputStream, fileName).toString();
     LOGGER.info("{} has been successfully stored and can be downloaded at {}", fileName, location);
 
     transformClient.requestTransform(fileSize, mimeType, location);

--- a/multi-int-store/src/main/java/com/connexta/multiintstore/adaptors/S3StorageAdaptor.java
+++ b/multi-int-store/src/main/java/com/connexta/multiintstore/adaptors/S3StorageAdaptor.java
@@ -8,6 +8,7 @@ package com.connexta.multiintstore.adaptors;
 
 import com.connexta.multiintstore.common.exceptions.StorageException;
 import java.io.IOException;
+import java.io.InputStream;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
@@ -16,7 +17,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.exception.SdkException;
@@ -45,7 +45,7 @@ public class S3StorageAdaptor implements StorageAdaptor {
   @Override
   public void store(
       @NotEmpty final String mimeType,
-      @NotNull final MultipartFile file,
+      @NotNull final InputStream inputStream,
       @NotNull @Min(1L) @Max(10737418240L) final Long fileSize,
       @NotEmpty final String fileName,
       @NotEmpty final String key)
@@ -58,7 +58,7 @@ public class S3StorageAdaptor implements StorageAdaptor {
             .contentLength(fileSize)
             .metadata(ImmutableMap.of(FILE_NAME_METADATA_KEY, fileName))
             .build();
-    final RequestBody requestBody = RequestBody.fromInputStream(file.getInputStream(), fileSize);
+    final RequestBody requestBody = RequestBody.fromInputStream(inputStream, fileSize);
 
     log.info("Storing {} in bucket \"{}\" with key \"{}\"", fileName, s3BucketQuarantine, key);
     try {

--- a/multi-int-store/src/main/java/com/connexta/multiintstore/adaptors/StorageAdaptor.java
+++ b/multi-int-store/src/main/java/com/connexta/multiintstore/adaptors/StorageAdaptor.java
@@ -8,11 +8,11 @@ package com.connexta.multiintstore.adaptors;
 
 import com.connexta.multiintstore.common.exceptions.StorageException;
 import java.io.IOException;
+import java.io.InputStream;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
-import org.springframework.web.multipart.MultipartFile;
 
 public interface StorageAdaptor {
 
@@ -24,7 +24,7 @@ public interface StorageAdaptor {
    */
   void store(
       @NotEmpty final String mimeType,
-      @NotNull final MultipartFile file,
+      @NotNull final InputStream inputStream,
       @NotNull @Min(1L) @Max(10737418240L) final Long fileSize,
       @NotEmpty final String fileName,
       @NotEmpty final String key)

--- a/multi-int-store/src/main/java/com/connexta/multiintstore/common/MetadataStorageManager.java
+++ b/multi-int-store/src/main/java/com/connexta/multiintstore/common/MetadataStorageManager.java
@@ -10,10 +10,12 @@ import com.connexta.multiintstore.common.exceptions.StorageException;
 import com.connexta.multiintstore.models.IndexedProductMetadata;
 import com.connexta.multiintstore.services.api.Dao;
 import java.io.IOException;
+import java.io.InputStream;
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.IOUtils;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @Service
@@ -28,16 +30,16 @@ public class MetadataStorageManager {
   }
 
   public void storeMetadata(
-      String acceptVersion,
-      String productId,
-      String metadataType,
-      String mimeType,
-      MultipartFile file,
-      String fileName)
+      @NotEmpty String acceptVersion,
+      @NotEmpty String productId,
+      @NotEmpty String metadataType,
+      @NotEmpty String mimeType,
+      @NotNull InputStream inputStream,
+      @NotEmpty String fileName)
       throws IOException, StorageException {
     if (metadataType.equals(INDEXED_PRODUCT_METADATA_CALLBACK_TYPE)) {
       final IndexedProductMetadata indexedProductMetadata =
-          new IndexedProductMetadata(productId, new String(file.getBytes(), "UTF-8"));
+          new IndexedProductMetadata(productId, IOUtils.toString(inputStream, "UTF-8"));
       log.info("Attempting to store {} with name \"{}\" in Solr", metadataType, fileName);
       cstDao.save(indexedProductMetadata);
     } else {

--- a/multi-int-store/src/main/java/com/connexta/multiintstore/common/ProductStorageManager.java
+++ b/multi-int-store/src/main/java/com/connexta/multiintstore/common/ProductStorageManager.java
@@ -10,6 +10,7 @@ import com.connexta.multiintstore.adaptors.RetrieveResponse;
 import com.connexta.multiintstore.adaptors.StorageAdaptor;
 import com.connexta.multiintstore.common.exceptions.StorageException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.UUID;
@@ -20,7 +21,6 @@ import javax.validation.constraints.NotNull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @Service
@@ -37,16 +37,16 @@ public class ProductStorageManager {
   }
 
   public URI storeProduct(
-      String acceptVersion,
+      @NotEmpty String acceptVersion,
       @NotNull @Min(1L) @Max(10737418240L) Long fileSize,
-      String mimeType,
-      MultipartFile file,
-      String fileName)
+      @NotEmpty String mimeType,
+      @NotNull InputStream inputStream,
+      @NotEmpty String fileName)
       throws IOException, StorageException, URISyntaxException {
     // TODO: Validate Accept-Version
     final String key = UUID.randomUUID().toString().replace("-", "");
 
-    storageAdaptor.store(mimeType, file, fileSize, fileName, key);
+    storageAdaptor.store(mimeType, inputStream, fileSize, fileName, key);
     return new URI(retrieveEndpoint + key);
   }
 
@@ -54,7 +54,7 @@ public class ProductStorageManager {
    * The caller is responsible for closing the {@link java.io.InputStream} in the returned {@link
    * RetrieveResponse}.
    */
-  public RetrieveResponse retrieveProduct(String id) throws StorageException {
+  public RetrieveResponse retrieveProduct(@NotEmpty String id) throws StorageException {
     return storageAdaptor.retrieve(id);
   }
 }

--- a/multi-int-store/src/main/java/com/connexta/multiintstore/controllers/RetrieveController.java
+++ b/multi-int-store/src/main/java/com/connexta/multiintstore/controllers/RetrieveController.java
@@ -11,6 +11,7 @@ import com.connexta.multiintstore.common.ProductStorageManager;
 import com.connexta.multiintstore.services.api.RetrieveApi;
 import java.io.IOException;
 import java.io.InputStream;
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.InputStreamResource;
@@ -34,7 +35,7 @@ public class RetrieveController implements RetrieveApi {
   }
 
   @Override
-  public ResponseEntity<Resource> retrieveProduct(String productId) {
+  public @NotNull ResponseEntity<Resource> retrieveProduct(@NotEmpty String productId) {
     InputStream inputStream = null;
     try {
       final RetrieveResponse retrieveResponse = productStorageManager.retrieveProduct(productId);

--- a/multi-int-store/src/main/java/com/connexta/multiintstore/services/api/RetrieveApi.java
+++ b/multi-int-store/src/main/java/com/connexta/multiintstore/services/api/RetrieveApi.java
@@ -6,6 +6,8 @@
  */
 package com.connexta.multiintstore.services.api;
 
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 import org.springframework.core.io.Resource;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -17,5 +19,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 public interface RetrieveApi {
 
   @GetMapping(value = "/product/{productId}")
-  ResponseEntity<Resource> retrieveProduct(@PathVariable(value = "productId") String productId);
+  @NotNull
+  ResponseEntity<Resource> retrieveProduct(
+      @PathVariable(value = "productId") @NotEmpty String productId);
 }

--- a/multi-int-store/src/main/java/com/connexta/multiintstore/services/api/StoreApi.java
+++ b/multi-int-store/src/main/java/com/connexta/multiintstore/services/api/StoreApi.java
@@ -9,6 +9,7 @@ package com.connexta.multiintstore.services.api;
 import javax.validation.Valid;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -30,12 +31,11 @@ public interface StoreApi {
       consumes = {"multipart/form-data"},
       method = RequestMethod.POST)
   ResponseEntity<Void> storeProduct(
-      @RequestHeader(value = "Accept-Version", required = true) String acceptVersion,
-      @RequestParam(value = "fileSize", required = true) @NotNull @Min(1L) @Max(10737418240L)
-          Long fileSize,
-      @RequestParam(value = "mimeType", required = true) String mimeType,
-      @Valid @RequestPart("file") MultipartFile file,
-      @RequestParam(value = "fileName", required = false) String fileName);
+      @RequestHeader(value = "Accept-Version") @NotEmpty String acceptVersion,
+      @RequestParam(value = "fileSize") @NotNull @Min(1L) @Max(10737418240L) Long fileSize,
+      @RequestParam(value = "mimeType") @NotEmpty String mimeType,
+      @Valid @RequestPart("file") @NotNull MultipartFile file,
+      @RequestParam(value = "fileName") @NotEmpty String fileName);
 
   @RequestMapping(
       value = "/product/{productId}/{metadataType}",
@@ -43,12 +43,11 @@ public interface StoreApi {
       consumes = {"multipart/form-data"},
       method = RequestMethod.PUT)
   ResponseEntity<Void> storeMetadata(
-      @RequestHeader(value = "Accept-Version", required = true) String acceptVersion,
-      @PathVariable(value = "productId", required = true) String productId,
-      @PathVariable(value = "metadataType", required = true) String metadataType,
-      @RequestParam(value = "fileSize", required = true) @NotNull @Min(1L) @Max(10737418240L)
-          Long fileSize,
-      @RequestParam(value = "mimeType", required = true) String mimeType,
-      @Valid @RequestPart("file") MultipartFile file,
-      @RequestParam(value = "fileName", required = false) String fileName);
+      @RequestHeader(value = "Accept-Version") @NotEmpty String acceptVersion,
+      @PathVariable(value = "productId") @NotEmpty String productId,
+      @PathVariable(value = "metadataType") @NotEmpty String metadataType,
+      @RequestParam(value = "fileSize") @NotNull @Min(1L) @Max(10737418240L) Long fileSize,
+      @RequestParam(value = "mimeType") @NotEmpty String mimeType,
+      @Valid @RequestPart("file") @NotNull MultipartFile file,
+      @RequestParam(value = "fileName") @NotEmpty String fileName);
 }


### PR DESCRIPTION
This PR updates both the ingest app and mis app to only use MultipartFile in the `@RestController` classes to make the apps less coupled to spring web.