### PR TITLE
Actuator for ingest and MIS services

### DIFF
--- a/buildSrc/src/main/groovy/Dependencies.groovy
+++ b/buildSrc/src/main/groovy/Dependencies.groovy
@@ -13,10 +13,10 @@ class Dependencies {
   static def ingestAPI = { it=Versions.ingestAPI -> "com.connexta.ingest:ingest-api-rest-spring-stubs:${it}" }
   static def lombok = { it=Versions.lombok -> "org.projectlombok:lombok:${it}" }
   static def reactiveStreams = { it=Versions.reactiveStreams -> "org.reactivestreams:reactive-streams:${it}" }
+  static def springActuator = { it=Versions.springBoot -> "org.springframework.boot:spring-boot-starter-actuator:${it}" }
   static def springBootStarterWeb = { it=Versions.springBoot -> "org.springframework.boot:spring-boot-starter-web:${it}" }
   static def springDataSolr = { it=Versions.springData -> "org.springframework.data:spring-data-solr:${it}" }
   static def transformAPI = { it=Versions.transformAPI -> "com.connexta.transformation:transformation-api-rest-spring-stubs:${it}" }
-  static def springActuator = { it=Versions.springBoot -> "org.springframework.boot:spring-boot-starter-actuator:${it}" }
 
 
   //  Test Dependencies

--- a/buildSrc/src/main/groovy/Dependencies.groovy
+++ b/buildSrc/src/main/groovy/Dependencies.groovy
@@ -16,6 +16,8 @@ class Dependencies {
   static def springBootStarterWeb = { it=Versions.springBoot -> "org.springframework.boot:spring-boot-starter-web:${it}" }
   static def springDataSolr = { it=Versions.springData -> "org.springframework.data:spring-data-solr:${it}" }
   static def transformAPI = { it=Versions.transformAPI -> "com.connexta.transformation:transformation-api-rest-spring-stubs:${it}" }
+  static def springActuator = { it=Versions.springBoot -> "org.springframework.boot:spring-boot-starter-actuator:${it}" }
+
 
   //  Test Dependencies
   static def hamcrestOptional = { it=Versions.npathai -> "com.github.npathai:hamcrest-optional:${it}" }

--- a/ingest/build.gradle
+++ b/ingest/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     implementation(Dependencies.commonsIO())
     implementation(Dependencies.ingestAPI())
     implementation(Dependencies.transformAPI())
+    implementation(Dependencies.springActuator())
     testImplementation(Dependencies.springBootStarterTest())
 }
 

--- a/ingest/src/main/resources/application.yml
+++ b/ingest/src/main/resources/application.yml
@@ -7,7 +7,6 @@ management:
     web:
       exposure:
         include: "*"
-        exclude: "/actuator"
 endpoints:
   transform:
     version: ${transformApiVersion}

--- a/multi-int-store/build.gradle
+++ b/multi-int-store/build.gradle
@@ -23,6 +23,7 @@ dependencies {
         because "Zookeeper 3.4.14 is a transitive dependency of org.springframework.data:spring-data-solr:4.0.9.RELEASE and is affected by CVE-2019-0232."
     }
     implementation(Dependencies.springDataSolr())
+    implementation(Dependencies.springActuator())
     testImplementation(Dependencies.springBootStarterTest())
     testImplementation(Dependencies.testContainers())
     testImplementation(Dependencies.restito())

--- a/multi-int-store/src/main/resources/application.yml
+++ b/multi-int-store/src/main/resources/application.yml
@@ -1,6 +1,7 @@
 logging:
   level:
-    ROOT: DEBUG
+    org.springframework.web.filter.CommonsRequestLoggingFilter: DEBUG
+    org.springframework.web.client: DEBUG
 
 management:
   endpoints:

--- a/multi-int-store/src/main/resources/application.yml
+++ b/multi-int-store/src/main/resources/application.yml
@@ -1,14 +1,12 @@
 logging:
   level:
-    org.springframework.web.filter.CommonsRequestLoggingFilter: DEBUG
-    org.springframework.web.client: DEBUG
+    ROOT: DEBUG
 
 management:
   endpoints:
     web:
       exposure:
         include: "*"
-        exclude: "/actuator"
 
 spring:
   profiles:


### PR DESCRIPTION
Adds in dependencies and configurations for Spring Boot Actuator. 
Configured to expose all Actuator endpoints.

To test (using *local deployment*), enter an actuator endpoint into a browser. E.g.

`http://127.0.0.1:9040/actuator/httptrace`
`http://127.0.0.1:9041/actuator`