### PR TITLE
Updated org.owasp.dependencycheck to the latest version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
 
 plugins {
     id "java"
-    id "org.owasp.dependencycheck" version "5.1.0"
+    id "org.owasp.dependencycheck" version "5.1.1"
     id "com.diffplug.gradle.spotless" version "3.23.1"
     id "org.sonarqube" version "2.7.1"
 }

--- a/ingest/owasp-suppressions.xml
+++ b/ingest/owasp-suppressions.xml
@@ -1,23 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd">
     <suppress>
-        <!-- Jackson vulnerability, nothing to do with jackson-databind-nullable -->
-        <notes><![CDATA[
-        file name: jackson-databind-nullable-0.1.0.jar
-        ]]></notes>
-        <gav regex="true">^org\.openapitools:jackson-databind-nullable:.*$</gav>
-        <cpe>cpe:/a:fasterxml:jackson</cpe>
-    </suppress>
-    <suppress>
-        <!-- Only affects gradle versions 1.4 to 5.3.1, but this project is using gradle 5.4.1 -->
-        <notes><![CDATA[
-        file name: springfox-*-2.9.2.jar
-        ]]></notes>
-        <gav regex="true">^io\.springfox:springfox-.*:.*$</gav>
-        <cpe>cpe:/a:gradle:gradle</cpe>
-        <cve>CVE-2019-11065</cve>
-    </suppress>
-    <suppress>
         <!-- Only present when JDOM 1.x or 2.x jar is in the classpath. JDOM has been excluded. -->
         <notes><![CDATA[
         file name: jackson-databind-2.9.9.jar


### PR DESCRIPTION
and remove unneeded suppressions

The one remaining suppression (for jackson-databind) will be removed after the ingest-api version is updated to 0.2.0 or later.