### PR TITLE
Update ingest API version and remove CVE suppression

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,10 +18,17 @@ buildscript {
 }
 
 plugins {
-    id "java"
-    id "org.owasp.dependencycheck" version "5.1.1"
     id "com.diffplug.gradle.spotless" version "3.23.1"
+    id "java"
+    id "maven"
+    id "org.owasp.dependencycheck" version "5.1.1"
     id "org.sonarqube" version "2.7.1"
+}
+
+repositories {
+    maven {
+        url "http://nexus.phx.connexta.com:8081/nexus/content/groups/public"
+    }
 }
 
 allprojects {
@@ -29,7 +36,7 @@ allprojects {
     sourceCompatibility = Versions.java
     targetCompatibility = Versions.java
 
-    if(sourceCompatibility != Jvm.current().javaVersion) {
+    if (sourceCompatibility != Jvm.current().javaVersion) {
         throw new Exception("You need Java ${sourceCompatibility} to build and run ${project.name}.\n" +
                 "The current version installed is ${Jvm.current().javaVersion.majorVersion}.\n" +
                 "For further reading see: \n\t> " +
@@ -91,8 +98,8 @@ subprojects {
         outputs.upToDateWhen { false }
 
         def styler = [(TestResult.ResultType.FAILURE): { msg -> "\033[31m${msg}\033[0m" },
-                    (TestResult.ResultType.SKIPPED): { msg -> "\033[33m${msg}\033[0m" },
-                    (TestResult.ResultType.SUCCESS): { msg -> "\033[32m${msg}\033[0m" }]
+                      (TestResult.ResultType.SKIPPED): { msg -> "\033[33m${msg}\033[0m" },
+                      (TestResult.ResultType.SUCCESS): { msg -> "\033[32m${msg}\033[0m" }]
 
 
         if (project.skipIntegrationTests()) {
@@ -135,16 +142,15 @@ subprojects {
                 def stack = []
                 if (project.quietTest()) {
                     def toTake = 1
-                    for(def ele : result.exception.getStackTrace()) {
-                        if(ele.getClassName() == desc.className) {
+                    for (def ele : result.exception.getStackTrace()) {
+                        if (ele.getClassName() == desc.className) {
                             break
                         }
                         toTake++
                     }
                     stack = result.exception.getStackTrace().take(toTake) +
                             "... ${result.exception.getStackTrace().length - toTake} more"
-                }
-                else {
+                } else {
                     stack = result.exception.getStackTrace()
                 }
                 logger.lifecycle("\n${styler[result.resultType](result.exception)}\n\t" +
@@ -167,7 +173,9 @@ subprojects {
     repositories {
         mavenLocal()
         mavenCentral()
-        maven { url = uri("http://nexus.phx.connexta.com:8081/nexus/content/repositories/ion-releases/") }
+        maven {
+            url = uri("http://nexus.phx.connexta.com:8081/nexus/content/repositories/ion-releases/")
+        }
         maven { url = uri("http://nexus.phx.connexta.com:8081/nexus/content/groups/public/") }
     }
 
@@ -184,7 +192,7 @@ subprojects {
 
 }
 
-task deploy(type:Exec) {
+task deploy(type: Exec) {
     dependsOn subprojects.build
     commandLine "./deploy.bash"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -25,12 +25,6 @@ plugins {
     id "org.sonarqube" version "2.7.1"
 }
 
-repositories {
-    maven {
-        url "http://nexus.phx.connexta.com:8081/nexus/content/groups/public"
-    }
-}
-
 allprojects {
 
     sourceCompatibility = Versions.java

--- a/build.gradle
+++ b/build.gradle
@@ -64,11 +64,6 @@ ext.skipIntegrationTests = {
     project.hasProperty("skipITests")
 }
 
-repositories {
-    mavenLocal()
-    mavenCentral()
-}
-
 subprojects {
     apply plugin: "java"
     apply plugin: "org.owasp.dependencycheck"
@@ -173,10 +168,7 @@ subprojects {
     repositories {
         mavenLocal()
         mavenCentral()
-        maven {
-            url = uri("http://nexus.phx.connexta.com:8081/nexus/content/repositories/ion-releases/")
-        }
-        maven { url = uri("http://nexus.phx.connexta.com:8081/nexus/content/groups/public/") }
+        maven { url "http://nexus.phx.connexta.com:8081/nexus/content/repositories/ion-releases/" }
     }
 
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,14 @@ allprojects {
         java SpotlessConfig.getJava(licenseFile)
         groovyGradle SpotlessConfig.getGroovy(licenseFile)
     }
+
+    configurations.all {
+        resolutionStrategy {
+            force Dependencies.guava,
+                    Dependencies.zookeeper,
+                    Dependencies.jacksonDatabind
+        }
+    }
 }
 
 ext.quietTest = {

--- a/buildSrc/src/main/groovy/Dependencies.groovy
+++ b/buildSrc/src/main/groovy/Dependencies.groovy
@@ -37,4 +37,7 @@ class Dependencies {
   static def zookeeper = "org.apache.zookeeper:zookeeper:]3.4.14,)"
   // CVE-2019-0232
   static def guava = "com.google.guava:guava:]24.1.1,)"
+  // CVE-2019-12384 and CVE-2019-1281
+  static def jacksonDatabind = "com.fasterxml.jackson.core:jackson-databind:[2.9.9.1,)"
+
 }

--- a/buildSrc/src/main/groovy/Dependencies.groovy
+++ b/buildSrc/src/main/groovy/Dependencies.groovy
@@ -10,7 +10,7 @@ class Dependencies {
   //  Dependencies
   static def awsS3 = { it=Versions.aws -> "software.amazon.awssdk:s3:${it}" }
   static def commonsIO = { it=Versions.commonsIO -> "commons-io:commons-io:${it}" }
-  static def ingestAPI = { it=Versions.ingestAPI -> "com.connexta.ingest:ingest-api-rest-spring-stubs:${it}" }
+  static def ingestAPI = { it=Versions.ingestAPI -> "com.connexta.ion.ingest:ingest-api-rest-spring-stubs:${it}" }
   static def lombok = { it=Versions.lombok -> "org.projectlombok:lombok:${it}" }
   static def reactiveStreams = { it=Versions.reactiveStreams -> "org.reactivestreams:reactive-streams:${it}" }
   static def springActuator = { it=Versions.springBoot -> "org.springframework.boot:spring-boot-starter-actuator:${it}" }

--- a/buildSrc/src/main/groovy/Versions.groovy
+++ b/buildSrc/src/main/groovy/Versions.groovy
@@ -13,7 +13,7 @@ class Versions {
     //  Versions
     static String aws = "2.5.69"
     static String commonsIO = "2.6"
-    static String ingestAPI = "0.1.1"
+    static String ingestAPI = "0.2.0"
     static String lombok = "1.18.8"
     static String reactiveStreams = "1.0.2"
     static String springBoot = "2.1.6.RELEASE"

--- a/ingest/build.gradle
+++ b/ingest/build.gradle
@@ -9,12 +9,6 @@ plugins {
     id "org.springframework.boot"
 }
 
-configurations {
-    implementation {
-        exclude group: "org.jdom" // CVE-2019-12814
-    }
-}
-
 dependencies {
     implementation(Dependencies.springBootStarterWeb())
     implementation(Dependencies.reactiveStreams())

--- a/ingest/owasp-suppressions.xml
+++ b/ingest/owasp-suppressions.xml
@@ -1,11 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd">
-    <suppress>
-        <!-- Only present when JDOM 1.x or 2.x jar is in the classpath. JDOM has been excluded. -->
-        <notes><![CDATA[
-        file name: jackson-databind-2.9.9.jar
-        ]]></notes>
-        <gav regex="true">^com\.fasterxml\.jackson\.core:jackson-databind:.*$</gav>
-        <cve>CVE-2019-12814</cve>
-    </suppress>
 </suppressions>

--- a/ingest/src/main/java/com/connexta/ingest/endpoint/IngestController.java
+++ b/ingest/src/main/java/com/connexta/ingest/endpoint/IngestController.java
@@ -34,12 +34,7 @@ public class IngestController implements IngestApi {
 
   @Override
   public ResponseEntity<Void> ingest(
-      String acceptVersion,
-      Long fileSize,
-      String mimeType,
-      MultipartFile file,
-      String title,
-      String fileName) {
+      String acceptVersion, String fileName, Long fileSize, String mimeType, MultipartFile file) {
     // TODO validate fileSize
 
     log.info("Attempting to ingest {}", fileName);
@@ -57,21 +52,19 @@ public class IngestController implements IngestApi {
       ingestService.ingest(fileSize, mimeType, file.getInputStream(), fileName);
     } catch (StoreException | TransformException e) {
       log.warn(
-          "Unable to complete ingest request with params acceptVersion={}, fileSize={}, mimeType={}, title={}, fileName={}",
+          "Unable to complete ingest request with params acceptVersion={}, fileSize={}, mimeType={}, fileName={}",
           acceptVersion,
           fileSize,
           mimeType,
-          title,
           fileName,
           e);
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
     } catch (IOException e) {
       log.warn(
-          "Unable to read file for ingest request with params acceptVersion={}, fileSize={}, mimeType={}, title={}, fileName={}",
+          "Unable to read file for ingest request with params acceptVersion={}, fileSize={}, mimeType={}, fileName={}",
           acceptVersion,
           fileSize,
           mimeType,
-          title,
           fileName,
           e);
       return ResponseEntity.badRequest().build();

--- a/multi-int-store/build.gradle
+++ b/multi-int-store/build.gradle
@@ -9,12 +9,6 @@ plugins {
     id "org.springframework.boot"
 }
 
-configurations {
-    implementation {
-        exclude group: "org.jdom" // CVE-2019-12814
-    }
-}
-
 configurations.all {
     resolutionStrategy {
         force Dependencies.guava,

--- a/multi-int-store/owasp-suppressions.xml
+++ b/multi-int-store/owasp-suppressions.xml
@@ -1,11 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd">
-    <suppress>
-        <!-- Only present when JDOM 1.x or 2.x jar is in the classpath. JDOM has been excluded. -->
-        <notes><![CDATA[
-        file name: jackson-databind-2.9.9.jar
-        ]]></notes>
-        <gav regex="true">^com\.fasterxml\.jackson\.core:jackson-databind:.*$</gav>
-        <cve>CVE-2019-12814</cve>
-    </suppress>
+
 </suppressions>


### PR DESCRIPTION
- Updates the applications to use version 0.2.0 of the Ion Ingest API. 
- ~~Instructs gradle to also look in the CX PHX nexus for artifacts~~ Already config to use CX PHX nexus
- Removes a CVE suppression that is no longer necessary because the new Ion Ingest API artifacts use a different version of a library.