### PR TITLE
Enable local JVM monitoring

### DIFF
--- a/deployments/local-minio/README.md
+++ b/deployments/local-minio/README.md
@@ -11,12 +11,18 @@ includes a deploy.sh file that will attempt to create the docker network needed.
 * Linux/Mac
 
 ## How to Run
-From this directory, run and follow the prompts to complete deployment:
-```
+From this directory:
+```bash
 ./deploy.sh
 ```
 The script should provide appropriate error messages to resolve any issues that may occur while setting up
 the docker network or deploying the images.
+
+## How to Stop
+From this directory:
+```bash
+./deploy.sh clean
+```
 
 ## Minio
 The minio web client is exposed on port 9000 with the default login information:

--- a/deployments/local-minio/docker-override.yml
+++ b/deployments/local-minio/docker-override.yml
@@ -13,6 +13,17 @@ services:
     networks:
       - cdr
     command: -c "mkdir /data/ingest-quarantine && /usr/bin/minio server /data"
+  # Enable JVM monitoring
+  ingest:
+    ports:
+      - target: 10040
+        published: 10040
+        protocol: tcp
+  multi-int-store:
+    ports:
+      - target: 10041
+        published: 10041
+        protocol: tcp
 
 secrets:
   # Directories are relative to the master compose file

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,9 +31,6 @@ services:
       - target: 8080
         published: 9040
         protocol: tcp
-      - target: 10040
-        published: 10040
-        protocol: tcp
       - target: 10050
         published: 10050
         protocol: tcp
@@ -56,9 +53,6 @@ services:
     ports:
       - target: 8080
         published: 9041
-        protocol: tcp
-      - target: 10041
-        published: 10041
         protocol: tcp
       - target: 10051
         published: 10051

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,12 @@ services:
       - target: 8080
         published: 9040
         protocol: tcp
+      - target: 10040
+        published: 10040
+        protocol: tcp
+      - target: 10050
+        published: 10050
+        protocol: tcp
     networks:
       - cdr
     deploy:
@@ -51,7 +57,12 @@ services:
       - target: 8080
         published: 9041
         protocol: tcp
-    restart: on-failure
+      - target: 10041
+        published: 10041
+        protocol: tcp
+      - target: 10051
+        published: 10051
+        protocol: tcp
     networks:
       - cdr
     depends_on:

--- a/ingest/Dockerfile
+++ b/ingest/Dockerfile
@@ -4,4 +4,14 @@ LABEL com.connexta.application.name=cdr-ingest
 ARG JAR_FILE
 COPY ${JAR_FILE} /cdr-ingest
 ENTRYPOINT ["/cdr-ingest"]
-EXPOSE 8080
+EXPOSE 8080 10040 10050
+# Enable JMX so the can JVM be monitored
+# NOTE: The exposed JMX port number must be the same as the port number published in the docker compose or stack file.
+ENV JAVA_TOOL_OPTIONS "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:10050 \
+-Dcom.sun.management.jmxremote \
+-Dcom.sun.management.jmxremote.port=10040 \
+-Dcom.sun.management.jmxremote.rmi.port=10040 \
+-Dcom.sun.management.jmxremote.ssl=false \
+-Dcom.sun.management.jmxremote.authenticate=false \
+-Djava.rmi.server.hostname=0.0.0.0 \
+-Dcom.sun.management.jmxremote.local.only=false"

--- a/multi-int-store/Dockerfile
+++ b/multi-int-store/Dockerfile
@@ -1,7 +1,17 @@
-FROM openjdk:11-jre-slim
+FROM openjdk:11
 LABEL maintainer=connexta
 LABEL com.connexta.application.name=multi-int-store
 ARG JAR_FILE
 COPY ${JAR_FILE} /multi-int-store
 ENTRYPOINT ["/multi-int-store"]
-EXPOSE 8080
+EXPOSE 8080 10041 10051
+# Enable JMX so the can JVM be monitored
+# NOTE: The exposed JMX port number must be the same as the port number published in the docker compose or stack file.
+ENV JAVA_TOOL_OPTIONS "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:10051 \
+-Dcom.sun.management.jmxremote \
+-Dcom.sun.management.jmxremote.port=10041 \
+-Dcom.sun.management.jmxremote.rmi.port=10041 \
+-Dcom.sun.management.jmxremote.ssl=false \
+-Dcom.sun.management.jmxremote.authenticate=false \
+-Djava.rmi.server.hostname=0.0.0.0 \
+-Dcom.sun.management.jmxremote.local.only=false"


### PR DESCRIPTION
Expose JMX service for Ingest and MIS. This permits monitoring the JVM including the size of the head. Also, enable and expose Java debugger.

To Test JMX:
1. Build the branch and deploy locally
2. Download and run visualvm (https://visualvm.github.io/)
3. In visualvm, add a JMX connection for ingest (localhost:10040). There should be no connection error.
4. In visualvm, add JMX connection for MIS (localhost:10041). There should be no connection error.

To test debugger. 
1. Run the app locally.
2. Attach debugger to ingest application. This is the IntelliJ configuration:

![image](https://user-images.githubusercontent.com/133284/61894836-16282c80-aec6-11e9-9c68-3d46cdf8dc13.png)


When the day comes to harden the system, this functionality will be turned off.