### PR TITLE
Updated the search endpoint to return URIs instead of URLs

### DIFF
--- a/multi-int-store/src/main/java/com/connexta/multiintstore/controllers/QueryController.java
+++ b/multi-int-store/src/main/java/com/connexta/multiintstore/controllers/QueryController.java
@@ -8,7 +8,7 @@ package com.connexta.multiintstore.controllers;
 
 import com.connexta.multiintstore.common.exceptions.SearchException;
 import com.connexta.multiintstore.services.api.SearchService;
-import java.net.URL;
+import java.net.URI;
 import java.util.List;
 import javax.validation.ConstraintViolationException;
 import javax.validation.constraints.NotBlank;
@@ -40,7 +40,7 @@ public class QueryController {
 
   @GetMapping
   @ResponseBody
-  public ResponseEntity<List<URL>> searchKeyword(
+  public ResponseEntity<List<URI>> searchKeyword(
       @RequestParam(value = "q") @NotBlank final String keyword) {
     try {
       return new ResponseEntity<>(searchService.find(keyword), HttpStatus.OK);

--- a/multi-int-store/src/main/java/com/connexta/multiintstore/services/api/SearchService.java
+++ b/multi-int-store/src/main/java/com/connexta/multiintstore/services/api/SearchService.java
@@ -8,12 +8,12 @@ package com.connexta.multiintstore.services.api;
 
 import com.connexta.multiintstore.common.exceptions.SearchException;
 import com.connexta.multiintstore.models.IndexedProductMetadata;
-import java.net.URL;
+import java.net.URI;
 import java.util.List;
 
 public interface SearchService {
 
   void store(IndexedProductMetadata doc);
 
-  List<URL> find(String keyword) throws SearchException;
+  List<URI> find(String keyword) throws SearchException;
 }

--- a/multi-int-store/src/main/java/com/connexta/multiintstore/services/impl/SearchServiceImpl.java
+++ b/multi-int-store/src/main/java/com/connexta/multiintstore/services/impl/SearchServiceImpl.java
@@ -10,8 +10,8 @@ import com.connexta.multiintstore.common.exceptions.SearchException;
 import com.connexta.multiintstore.models.IndexedProductMetadata;
 import com.connexta.multiintstore.repositories.IndexedMetadataRepository;
 import com.connexta.multiintstore.services.api.SearchService;
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -40,7 +40,7 @@ public class SearchServiceImpl implements SearchService {
   }
 
   @Override
-  public List<URL> find(String keyword) throws SearchException {
+  public List<URI> find(String keyword) throws SearchException {
     final List<IndexedProductMetadata> matchingIndexedProductMetadatas;
     try {
       matchingIndexedProductMetadatas = indexedMetadataRepository.findByContents(keyword);
@@ -55,23 +55,23 @@ public class SearchServiceImpl implements SearchService {
       throw new SearchException("Unable to search for " + keyword, e);
     }
 
-    final List<URL> urls = new ArrayList<>();
+    final List<URI> uris = new ArrayList<>();
     for (final IndexedProductMetadata indexedProductMetadata : matchingIndexedProductMetadatas) {
       final String id = indexedProductMetadata.getId();
-      final URL url;
+      final URI uri;
       try {
-        url = new URL(endpointUrlRetrieve + id);
-      } catch (MalformedURLException e) {
+        uri = new URI(endpointUrlRetrieve + id);
+      } catch (URISyntaxException e) {
         throw new SearchException(
-            "Unable to construct retrieve URL from endpointUrlRetrieve="
+            "Unable to construct retrieve URI from endpointUrlRetrieve="
                 + endpointUrlRetrieve
                 + " and id="
                 + id,
             e);
       }
-      urls.add(url);
+      uris.add(uri);
     }
 
-    return Collections.unmodifiableList(urls);
+    return Collections.unmodifiableList(uris);
   }
 }


### PR DESCRIPTION
This PR updates the query endpoint to return URIs instead of URLs to match the type of the `Location` header in the store product response.