### PR TITLE
Resolve ingest memory usage

### DIFF
--- a/ingest/src/main/java/com/connexta/ingest/client/StoreClient.java
+++ b/ingest/src/main/java/com/connexta/ingest/client/StoreClient.java
@@ -25,9 +25,8 @@ import org.springframework.web.client.RestTemplate;
 @Slf4j
 public class StoreClient {
 
-  @NotNull private final RestTemplate restTemplate;
-
   @NotBlank private final String storeEndpoint;
+  @NotNull private final RestTemplate restTemplate;
 
   public StoreClient(
       @NotNull final RestTemplate restTemplate, @NotBlank final String storeEndpoint) {

--- a/multi-int-store/src/main/java/com/connexta/multiintstore/controllers/StoreController.java
+++ b/multi-int-store/src/main/java/com/connexta/multiintstore/controllers/StoreController.java
@@ -43,7 +43,7 @@ public class StoreController implements StoreApi {
   }
 
   @Override
-  public ResponseEntity<Void> storeProduct(
+  public ResponseEntity<URI> storeProduct(
       @NotBlank String acceptVersion,
       @NotNull @Min(1L) @Max(10737418240L) Long fileSize,
       @NotBlank String mimeType,
@@ -88,7 +88,7 @@ public class StoreController implements StoreApi {
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
     }
 
-    return ResponseEntity.created(location).build();
+    return ResponseEntity.created(location).body(location);
   }
 
   @Override

--- a/multi-int-store/src/main/java/com/connexta/multiintstore/services/api/StoreApi.java
+++ b/multi-int-store/src/main/java/com/connexta/multiintstore/services/api/StoreApi.java
@@ -6,6 +6,7 @@
  */
 package com.connexta.multiintstore.services.api;
 
+import java.net.URI;
 import javax.validation.Valid;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
@@ -30,7 +31,7 @@ public interface StoreApi {
       produces = {"application/json"},
       consumes = {"multipart/form-data"},
       method = RequestMethod.POST)
-  ResponseEntity<Void> storeProduct(
+  ResponseEntity<URI> storeProduct(
       @RequestHeader(value = "Accept-Version") @NotBlank String acceptVersion,
       @RequestParam(value = "fileSize") @NotNull @Min(1L) @Max(10737418240L) Long fileSize,
       @RequestParam(value = "mimeType") @NotBlank String mimeType,


### PR DESCRIPTION
Disable HTTP buffering when storing a file.
The changes are isolated to a new bean ("nonBuggeringRestTemplate")
This might be a change we want to make to the general RestTemplate bean because it cuts down on memory usage. 