### PR TITLE
Non-buffering Rest Template

### DIFF
--- a/ingest/src/main/java/com/connexta/ingest/config/StoreClientConfiguration.java
+++ b/ingest/src/main/java/com/connexta/ingest/config/StoreClientConfiguration.java
@@ -9,16 +9,26 @@ package com.connexta.ingest.config;
 import com.connexta.ingest.client.StoreClient;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class StoreClientConfiguration {
+
+  @Bean("nonBufferingRestTemplate")
+  public RestTemplate nonBufferingRestTemplate() {
+    SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+    requestFactory.setBufferRequestBody(false);
+    return new RestTemplate(requestFactory);
+  }
+
   @Bean
   public StoreClient storeClient(
-      @NotNull RestTemplate restTemplate,
+      @NotNull @Qualifier("nonBufferingRestTemplate") RestTemplate restTemplate,
       @NotBlank @Value("${endpointUrl.store}") String storeEndpoint) {
     return new StoreClient(restTemplate, storeEndpoint);
   }

--- a/ingest/src/test/java/com/connexta/ingest/IngestApplicationIntegrationTest.java
+++ b/ingest/src/test/java/com/connexta/ingest/IngestApplicationIntegrationTest.java
@@ -36,7 +36,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.client.MockRestServiceServer;
-import org.springframework.test.web.client.MockRestServiceServer.MockRestServiceServerBuilder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.client.RestTemplate;
 
@@ -71,9 +70,7 @@ public class IngestApplicationIntegrationTest {
 
   @Before
   public void beforeEach() {
-    MockRestServiceServerBuilder builder = MockRestServiceServer.bindTo(nonBufferingRestTemplate);
-    builder.bufferContent();
-    storeServer = builder.build();
+    storeServer = MockRestServiceServer.createServer(nonBufferingRestTemplate);
     transformServer = MockRestServiceServer.createServer(restTemplate);
   }
 


### PR DESCRIPTION
Disable HTTP buffering when storing a file.
The changes are isolated to a new bean ("nonBuggeringRestTemplate")
This might be a change we want to make to the shared RestTemplate bean -- the change reduces memory usage.