### PR TITLE
Fix local depolyment

### DIFF
--- a/deployments/local-minio/configs/ingest_config.yml
+++ b/deployments/local-minio/configs/ingest_config.yml
@@ -1,2 +1,2 @@
 endpointUrl:
-  store: http://cdr-store:9041/store/
+  store: http://multi-int-store:8080/mis/product

--- a/deployments/local-minio/configs/ingest_config.yml
+++ b/deployments/local-minio/configs/ingest_config.yml
@@ -1,2 +1,2 @@
 endpointUrl:
-  store: http://multi-int-store:8080/mis/product
+  store: http://multi-int-store:8080/mis/product/

--- a/deployments/local-minio/configs/mis_config.yml
+++ b/deployments/local-minio/configs/mis_config.yml
@@ -8,4 +8,4 @@ solr:
   host: solr
   port: 8983
 endpointUrl:
-  retrieve: http://cdr-ingest:9041/mis/product/
+  retrieve: http://multi-int-store:9041/mis/product/

--- a/deployments/local-minio/configs/mis_config.yml
+++ b/deployments/local-minio/configs/mis_config.yml
@@ -8,4 +8,4 @@ solr:
   host: solr
   port: 8983
 endpointUrl:
-  retrieve: http://multi-int-store:9041/mis/product/
+  retrieve: http://multi-int-store:8080/mis/product/

--- a/deployments/local-minio/configs/mis_config.yml
+++ b/deployments/local-minio/configs/mis_config.yml
@@ -8,4 +8,4 @@ solr:
   host: solr
   port: 8983
 endpointUrl:
-  retrieve: http://multi-int-store:8080/mis/product/
+  retrieve: http://localhost:9041/mis/product/

--- a/deployments/local-minio/docker-override.yml
+++ b/deployments/local-minio/docker-override.yml
@@ -4,7 +4,6 @@ services:
   minio:
     image: minio/minio
     entrypoint: sh
-    hostname: minio
     ports:
       - "9000:9000"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,6 @@ version: '3.7'
 services:
   ingest:
     image: ${REGISTRY:-docker.io}/cnxta/cdr-ingest:0.1.0-SNAPSHOT
-    hostname: cdr-ingest
     ports:
       - target: 8080
         published: 9040
@@ -49,7 +48,6 @@ services:
       - "--spring.config.additional-location=file:/configs/transform_config.yml"
   multi-int-store:
     image: ${REGISTRY:-docker.io}/cnxta/cdr-multi-int-store:0.1.0-SNAPSHOT
-    hostname: cdr-store
     ports:
       - target: 8080
         published: 9041


### PR DESCRIPTION
This PR restores local development functionality to that level it was when it was first released. 

- Change local deployment configs to use the service name associated with a container because that is the name that Docker puts into DNS.
 - Change local deployment configs to use the port number exposed in the Dockerfile for communication on the same docker overlay network.
- Remove the `hostname:` attribute from docker compose files because it is misleading. It only changes the hostname internally -- what is returned when executing `hostname` from the command line.

Testing:
Do: Build and deploy locally. Try the ingest, store, and retrieve endpoints.
Expect:
- Store and retrieve should work.
- Ingest should successfully store a product and get as far as sending a call to transform

I tried these same tests in the cloud to see if removing "hostname:" had any negative consequences. I got the results I expected.  The PR hero might want to double-check that and also test it in the cloud.