### PR TITLE
Replace @Autowired and @Qualifier annotations 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -176,7 +176,6 @@ subprojects {
     dependencies {
         compileOnly(Dependencies.lombok())
         annotationProcessor(Dependencies.lombok())
-
         //  Test Dependencies
         testImplementation(Dependencies.junit())
         testImplementation(Dependencies.mockito())

--- a/buildSrc/src/main/groovy/Dependencies.groovy
+++ b/buildSrc/src/main/groovy/Dependencies.groovy
@@ -11,6 +11,7 @@ class Dependencies {
   static def awsS3 = { it=Versions.aws -> "com.amazonaws:aws-java-sdk-s3:${it}" }
   static def commonsIO = { it=Versions.commonsIO -> "commons-io:commons-io:${it}" }
   static def ingestAPI = { it=Versions.ingestAPI -> "com.connexta.ion.ingest:ingest-api-rest-spring-stubs:${it}" }
+  static def javaxInject = { it=Versions.javaxInject -> "javax.inject:javax.inject:${it}"}
   static def lombok = { it=Versions.lombok -> "org.projectlombok:lombok:${it}" }
   static def springActuator = { it=Versions.springBoot -> "org.springframework.boot:spring-boot-starter-actuator:${it}" }
   static def springBootStarterWeb = { it=Versions.springBoot -> "org.springframework.boot:spring-boot-starter-web:${it}" }

--- a/buildSrc/src/main/groovy/Versions.groovy
+++ b/buildSrc/src/main/groovy/Versions.groovy
@@ -14,6 +14,7 @@ class Versions {
     static String aws = "1.11.592"
     static String commonsIO = "2.6"
     static String ingestAPI = "0.2.0"
+    static String javaxInject = "1"
     static String lombok = "1.18.8"
     static String springBoot = "2.1.6.RELEASE"
     static String springData = "4.0.9.RELEASE"

--- a/ingest/build.gradle
+++ b/ingest/build.gradle
@@ -13,10 +13,11 @@ dependencies {
     implementation(Dependencies.springBootStarterWeb())
     implementation(Dependencies.commonsIO())
     implementation(Dependencies.ingestAPI())
-    implementation(Dependencies.transformAPI())
+    implementation(Dependencies.javaxInject())
     implementation(Dependencies.springActuator())
     implementation(Dependencies.swagger())
     implementation(Dependencies.swaggerUi())
+    implementation(Dependencies.transformAPI())
     testImplementation(Dependencies.springBootStarterTest())
 }
 

--- a/ingest/src/main/java/com/connexta/ingest/config/StoreClientConfiguration.java
+++ b/ingest/src/main/java/com/connexta/ingest/config/StoreClientConfiguration.java
@@ -7,9 +7,9 @@
 package com.connexta.ingest.config;
 
 import com.connexta.ingest.client.StoreClient;
+import javax.inject.Named;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -28,7 +28,7 @@ public class StoreClientConfiguration {
 
   @Bean
   public StoreClient storeClient(
-      @NotNull @Qualifier("nonBufferingRestTemplate") RestTemplate restTemplate,
+      @NotNull @Named("nonBufferingRestTemplate") RestTemplate restTemplate,
       @NotBlank @Value("${endpointUrl.store}") String storeEndpoint) {
     return new StoreClient(restTemplate, storeEndpoint);
   }

--- a/ingest/src/test/java/com/connexta/ingest/IngestApplicationIntegrationTest.java
+++ b/ingest/src/test/java/com/connexta/ingest/IngestApplicationIntegrationTest.java
@@ -20,13 +20,13 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.net.URI;
+import javax.inject.Inject;
+import javax.inject.Named;
 import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -58,11 +58,11 @@ public class IngestApplicationIntegrationTest {
   @Value("${endpoints.transform.version}")
   private String endpointsTransformVersion;
 
-  @Autowired private MockMvc mvc;
-  @Autowired private RestTemplate restTemplate;
+  @Inject private MockMvc mvc;
+  @Inject private RestTemplate restTemplate;
 
-  @Autowired
-  @Qualifier("nonBufferingRestTemplate")
+  @Inject
+  @Named("nonBufferingRestTemplate")
   private RestTemplate nonBufferingRestTemplate;
 
   private MockRestServiceServer storeServer;

--- a/multi-int-store/build.gradle
+++ b/multi-int-store/build.gradle
@@ -18,7 +18,6 @@ configurations.all {
 
 dependencies {
     implementation(Dependencies.awsS3())
-    implementation(Dependencies.ingestAPI())
     implementation(Dependencies.javaxInject())
     implementation(Dependencies.springActuator())
     implementation(Dependencies.springBootStarterWeb())

--- a/multi-int-store/build.gradle
+++ b/multi-int-store/build.gradle
@@ -18,6 +18,8 @@ configurations.all {
 
 dependencies {
     implementation(Dependencies.awsS3())
+    implementation(Dependencies.ingestAPI())
+    implementation(Dependencies.javaxInject())
     implementation(Dependencies.springActuator())
     implementation(Dependencies.springBootStarterWeb())
     implementation(Dependencies.springDataSolr())

--- a/multi-int-store/src/test/java/com/connexta/multiintstore/QueryTests.java
+++ b/multi-int-store/src/test/java/com/connexta/multiintstore/QueryTests.java
@@ -15,6 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.amazonaws.services.s3.AmazonS3;
 import java.io.IOException;
+import javax.inject.Inject;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrQuery;
@@ -25,7 +26,6 @@ import org.apache.solr.common.params.SolrParams;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -45,7 +45,7 @@ public class QueryTests {
 
   @MockBean private SolrClient mockSolrClient;
 
-  @Autowired private MockMvc mockMvc;
+  @Inject private MockMvc mockMvc;
 
   @After
   public void after() {

--- a/multi-int-store/src/test/java/com/connexta/multiintstore/RetrieveProductTests.java
+++ b/multi-int-store/src/test/java/com/connexta/multiintstore/RetrieveProductTests.java
@@ -18,11 +18,11 @@ import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.internal.AmazonS3ExceptionBuilder;
 import com.amazonaws.services.s3.model.GetObjectRequest;
+import javax.inject.Inject;
 import org.apache.solr.client.solrj.SolrClient;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -44,7 +44,7 @@ public class RetrieveProductTests {
 
   @MockBean private AmazonS3 mockAmazonS3;
 
-  @Autowired private MockMvc mockMvc;
+  @Inject private MockMvc mockMvc;
 
   @Value("${aws.s3.bucket.quarantine}")
   private String s3Bucket;

--- a/multi-int-store/src/test/java/com/connexta/multiintstore/S3Tests.java
+++ b/multi-int-store/src/test/java/com/connexta/multiintstore/S3Tests.java
@@ -21,6 +21,7 @@ import java.net.URI;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import javax.inject.Inject;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.solr.client.solrj.SolrClient;
@@ -33,7 +34,6 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
@@ -96,8 +96,8 @@ public class S3Tests {
     }
   }
 
-  @Autowired private TestRestTemplate restTemplate;
-  @Autowired private AmazonS3 amazonS3;
+  @Inject private TestRestTemplate restTemplate;
+  @Inject private AmazonS3 amazonS3;
 
   @Value("${endpointUrl.retrieve}")
   private String endpointUrlRetrieve;

--- a/multi-int-store/src/test/java/com/connexta/multiintstore/SolrTests.java
+++ b/multi-int-store/src/test/java/com/connexta/multiintstore/SolrTests.java
@@ -27,6 +27,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import javax.inject.Inject;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.solr.client.solrj.SolrClient;
@@ -35,7 +36,6 @@ import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
@@ -83,8 +83,8 @@ public class SolrTests {
 
   @MockBean AmazonS3 mockAmazonS3;
 
-  @Autowired private TestRestTemplate restTemplate;
-  @Autowired private SolrClient solrClient;
+  @Inject private TestRestTemplate restTemplate;
+  @Inject private SolrClient solrClient;
 
   @Value("${aws.s3.bucket.quarantine}")
   private String s3Bucket;

--- a/multi-int-store/src/test/java/com/connexta/multiintstore/StoreMetadataTests.java
+++ b/multi-int-store/src/test/java/com/connexta/multiintstore/StoreMetadataTests.java
@@ -17,6 +17,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.amazonaws.services.s3.AmazonS3;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import javax.inject.Inject;
 import org.apache.commons.io.IOUtils;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrQuery;
@@ -27,7 +28,6 @@ import org.junit.After;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -49,7 +49,7 @@ public class StoreMetadataTests {
 
   @MockBean private SolrClient mockSolrClient;
 
-  @Autowired private MockMvc mockMvc;
+  @Inject private MockMvc mockMvc;
 
   @After
   public void after() {

--- a/multi-int-store/src/test/java/com/connexta/multiintstore/StoreProductTests.java
+++ b/multi-int-store/src/test/java/com/connexta/multiintstore/StoreProductTests.java
@@ -21,13 +21,13 @@ import com.amazonaws.services.s3.internal.AmazonS3ExceptionBuilder;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import javax.inject.Inject;
 import org.apache.commons.io.IOUtils;
 import org.apache.solr.client.solrj.SolrClient;
 import org.junit.After;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -50,7 +50,7 @@ public class StoreProductTests {
 
   @MockBean private AmazonS3 mockAmazonS3;
 
-  @Autowired private MockMvc mockMvc;
+  @Inject private MockMvc mockMvc;
 
   @Value("${aws.s3.bucket.quarantine}")
   private String s3Bucket;


### PR DESCRIPTION
Replaced `@Autowired` with `@Inject`
Attempted to replace `@Bean` with `@Named`, Spring failed to provide most of the beans.  Rather than leave a mix of `@Bean` and `@Named` I used `@Bean` consistently.