### PR TITLE
 Prevent storing of metadata that does not have an associated product

### DIFF
--- a/multi-int-store/src/main/java/com/connexta/multiintstore/adaptors/S3StorageAdaptor.java
+++ b/multi-int-store/src/main/java/com/connexta/multiintstore/adaptors/S3StorageAdaptor.java
@@ -120,6 +120,6 @@ public class S3StorageAdaptor implements StorageAdaptor {
 
   @Override
   public boolean objectExists(String key) {
-    return (amazonS3.doesObjectExist(bucket, key)) ? true : false;
+    return amazonS3.doesObjectExist(bucket, key);
   }
 }

--- a/multi-int-store/src/main/java/com/connexta/multiintstore/adaptors/S3StorageAdaptor.java
+++ b/multi-int-store/src/main/java/com/connexta/multiintstore/adaptors/S3StorageAdaptor.java
@@ -14,16 +14,15 @@ import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.transfer.TransferManager;
 import com.amazonaws.services.s3.transfer.Upload;
 import com.connexta.multiintstore.common.exceptions.StorageException;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.MediaType;
-import org.springframework.util.StringUtils;
-
+import java.io.IOException;
+import java.io.InputStream;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
-import java.io.IOException;
-import java.io.InputStream;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.util.StringUtils;
 
 @Slf4j
 public class S3StorageAdaptor implements StorageAdaptor {
@@ -67,7 +66,7 @@ public class S3StorageAdaptor implements StorageAdaptor {
     } catch (RuntimeException | InterruptedException e) {
       throw new StorageException(
           String.format(
-              "Unable to store \"%s\" in bucket \"%s\" with key \"%s\"", fileName, key, bucket),
+              "Unable to store \"%s\" in bucket \"%s\" with key \"%s\"", fileName, bucket, key),
           e);
     }
 

--- a/multi-int-store/src/main/java/com/connexta/multiintstore/adaptors/S3StorageAdaptor.java
+++ b/multi-int-store/src/main/java/com/connexta/multiintstore/adaptors/S3StorageAdaptor.java
@@ -14,15 +14,16 @@ import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.transfer.TransferManager;
 import com.amazonaws.services.s3.transfer.Upload;
 import com.connexta.multiintstore.common.exceptions.StorageException;
-import java.io.IOException;
-import java.io.InputStream;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.util.StringUtils;
+
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.MediaType;
-import org.springframework.util.StringUtils;
+import java.io.IOException;
+import java.io.InputStream;
 
 @Slf4j
 public class S3StorageAdaptor implements StorageAdaptor {
@@ -116,5 +117,10 @@ public class S3StorageAdaptor implements StorageAdaptor {
 
       throw t;
     }
+  }
+
+  @Override
+  public boolean objectExists(String key) {
+    return (amazonS3.doesObjectExist(bucket, key)) ? true : false;
   }
 }

--- a/multi-int-store/src/main/java/com/connexta/multiintstore/adaptors/StorageAdaptor.java
+++ b/multi-int-store/src/main/java/com/connexta/multiintstore/adaptors/StorageAdaptor.java
@@ -38,4 +38,6 @@ public interface StorageAdaptor {
    */
   @NotNull
   RetrieveResponse retrieve(@NotBlank final String key) throws StorageException;
+
+  boolean objectExists(@NotBlank String key);
 }

--- a/multi-int-store/src/main/java/com/connexta/multiintstore/common/MetadataStorageManager.java
+++ b/multi-int-store/src/main/java/com/connexta/multiintstore/common/MetadataStorageManager.java
@@ -6,9 +6,15 @@
  */
 package com.connexta.multiintstore.common;
 
+import com.connexta.multiintstore.adaptors.StorageAdaptor;
 import com.connexta.multiintstore.common.exceptions.StorageException;
 import com.connexta.multiintstore.models.IndexedProductMetadata;
 import com.connexta.multiintstore.services.api.Dao;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.IOUtils;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -24,9 +30,13 @@ public class MetadataStorageManager {
   private static final String SUPPORTED_METADATA_TYPE = "cst";
 
   private final Dao<IndexedProductMetadata, String> cstDao;
+  private final StorageAdaptor storageAdaptor;
 
-  public MetadataStorageManager(@NotNull final Dao<IndexedProductMetadata, String> cstDao) {
+  public MetadataStorageManager(
+      @NotNull final Dao<IndexedProductMetadata, String> cstDao,
+      @NotNull StorageAdaptor storageAdaptor) {
     this.cstDao = cstDao;
+    this.storageAdaptor = storageAdaptor;
   }
 
   public void storeMetadata(

--- a/multi-int-store/src/main/java/com/connexta/multiintstore/common/MetadataStorageManager.java
+++ b/multi-int-store/src/main/java/com/connexta/multiintstore/common/MetadataStorageManager.java
@@ -10,14 +10,13 @@ import com.connexta.multiintstore.adaptors.StorageAdaptor;
 import com.connexta.multiintstore.common.exceptions.StorageException;
 import com.connexta.multiintstore.models.IndexedProductMetadata;
 import com.connexta.multiintstore.services.api.Dao;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.io.IOUtils;
-
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.IOUtils;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import lombok.extern.slf4j.Slf4j;

--- a/multi-int-store/src/main/java/com/connexta/multiintstore/common/MetadataStorageManager.java
+++ b/multi-int-store/src/main/java/com/connexta/multiintstore/common/MetadataStorageManager.java
@@ -17,10 +17,6 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 
 @Slf4j
@@ -50,24 +46,31 @@ public class MetadataStorageManager {
       throw new UnsupportedOperationException(message);
     }
 
-    // TODO verify Media Typeype for CST
+    // TODO verify Media Type for CST
 
     storeCst(productId, inputStream);
   }
 
   private void storeCst(@NotBlank final String productId, @NotNull final InputStream inputStream)
       throws StorageException {
-    final IndexedProductMetadata indexedProductMetadata;
-    try {
-      indexedProductMetadata =
-          new IndexedProductMetadata(
-              productId, IOUtils.toString(inputStream, StandardCharsets.UTF_8));
-    } catch (IOException e) {
-      throw new StorageException("Unable to convert metadata to String", e);
-    }
+    if (storageAdaptor.objectExists(productId)) {
+      final IndexedProductMetadata indexedProductMetadata;
+      try {
+        indexedProductMetadata =
+            new IndexedProductMetadata(
+                productId, IOUtils.toString(inputStream, StandardCharsets.UTF_8));
+      } catch (IOException e) {
+        throw new StorageException("Unable to convert metadata to String", e);
+      }
 
-    log.info(
-        "Attempting to store {} metadata for product id {}", SUPPORTED_METADATA_TYPE, productId);
-    cstDao.save(indexedProductMetadata);
+      log.info(
+          "Attempting to store {} metadata for product id {}", SUPPORTED_METADATA_TYPE, productId);
+      cstDao.save(indexedProductMetadata);
+    } else {
+      throw new StorageException(
+          String.format(
+              "Unable to store Metadata because a product with key \"%s\" does not exist",
+              productId));
+    }
   }
 }

--- a/multi-int-store/src/main/java/com/connexta/multiintstore/config/StorageManagerConfiguration.java
+++ b/multi-int-store/src/main/java/com/connexta/multiintstore/config/StorageManagerConfiguration.java
@@ -28,7 +28,7 @@ public class StorageManagerConfiguration {
 
   @Bean
   public MetadataStorageManager metadataStorageManager(
-      @NotNull Dao<IndexedProductMetadata, String> cstDao) {
-    return new MetadataStorageManager(cstDao);
+      @NotNull Dao<IndexedProductMetadata, String> cstDao, @NotNull StorageAdaptor storageAdaptor) {
+    return new MetadataStorageManager(cstDao, storageAdaptor);
   }
 }

--- a/multi-int-store/src/main/java/com/connexta/multiintstore/controllers/StoreController.java
+++ b/multi-int-store/src/main/java/com/connexta/multiintstore/controllers/StoreController.java
@@ -108,7 +108,6 @@ public class StoreController implements StoreApi {
     final String mediaType = file.getContentType();
     // TODO verify that mediaType is not blank and is a valid Content Type
 
-    // TODO verify id matches something in S3 before storing to solr
     // TODO handle when CST has already been stored
 
     final InputStream inputStream;

--- a/multi-int-store/src/test/java/com/connexta/multiintstore/SolrTests.java
+++ b/multi-int-store/src/test/java/com/connexta/multiintstore/SolrTests.java
@@ -38,7 +38,6 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;


### PR DESCRIPTION
I added a check to ensure that we only store Metadata if we have a product that has the same ID in S3. This PR also clears out Solr between itests to ensure that stored metadata doesn't bleed over into the next test.