### PR TITLE
Add Dependabot config file

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,10 @@
+version: 1
+update_configs:
+  - package_manager: "java:gradle"
+    directory: "/"
+    update_schedule: "daily"
+    target_branch: "master"
+    default_reviewers:
+      - "jhunzik"
+      - "emmberk"
+      - "ahoffer"


### PR DESCRIPTION
We define our dependencies in a unique way, so this may not work right off the bat.