### PR TITLE
Update CI build to use linux-medium instead of linux-small

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ library 'github-utils-shared-library@master'
 pipeline {
     agent {
         node {
-            label 'linux-small'
+            label 'linux-medium'
             customWorkspace "/jenkins/workspace/${JOB_NAME}/${BUILD_NUMBER}"
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ library 'github-utils-shared-library@master'
 pipeline {
     agent {
         node {
-            label 'linux-medium'
+            label 'linux-large'
             customWorkspace "/jenkins/workspace/${JOB_NAME}/${BUILD_NUMBER}"
         }
     }


### PR DESCRIPTION
This might help address the issues we've been having with CI builds running out of resources. See
- https://github.com/connexta/multi-int-store/pull/133
- https://github.com/connexta/multi-int-store/pull/137

@LinkMJB